### PR TITLE
Add dedicated player pages and cross-link entities

### DIFF
--- a/baseball-history-tests/Pages/PageRoutingIntegrationTests.cs
+++ b/baseball-history-tests/Pages/PageRoutingIntegrationTests.cs
@@ -172,7 +172,7 @@ public class PageRoutingIntegrationTests(WebApplicationFactory<Program> factory)
     [InlineData("/About", ">About</h1>", "View Source on GitHub")]
     [InlineData("/ApiDocs", ">REST API</h1>", "/openapi/v1.json")]
     [InlineData("/McpDocs", ">MCP Server</h1>", "search_players")]
-    [InlineData("/Privacy", ">Privacy Policy</h1>", "Use this page to detail your site's privacy policy.")]
+    [InlineData("/Privacy", ">Privacy Policy</h1>", "do not collect, store, sell, or share")]
     [InlineData("/Health", ">Health Check</h1>", "Database Status")]
     [InlineData("/Error", ">Error</h1>", "Development Mode")]
     public async Task SupportPages_FullPage_RenderWithinShell(string route, string headingMarker, string contentMarker)

--- a/baseball-history-tests/Pages/PlayerDetailsPageTests.cs
+++ b/baseball-history-tests/Pages/PlayerDetailsPageTests.cs
@@ -1,0 +1,97 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace baseball_history_tests.Pages;
+
+public class PlayerDetailsPageTests(WebApplicationFactory<Program> factory) : IntegrationTestBase(factory)
+{
+    private const string TwoWayPlayerId = "ruthba01";
+
+    [Fact]
+    public async Task PlayerDetails_KnownPlayer_RendersFullPage()
+    {
+        var html = await GetStringAsync($"/Players/{TwoWayPlayerId}");
+
+        Assert.Contains("Babe Ruth", html);
+        Assert.Contains("id=\"player-details\"", html);
+        Assert.Contains("breadcrumb", html);
+        Assert.Contains("href=\"/Players\"", html);
+    }
+
+    [Fact]
+    public async Task PlayerDetails_TwoWayPlayer_ShowsBattingAndPitchingTabs()
+    {
+        var html = await GetStringAsync($"/Players/{TwoWayPlayerId}");
+
+        Assert.Contains($"batting-tab-{TwoWayPlayerId}", html);
+        Assert.Contains($"pitching-tab-{TwoWayPlayerId}", html);
+    }
+
+    [Fact]
+    public async Task PlayerDetails_HallOfFamer_LinksHofBadgeToInductionClass()
+    {
+        var html = await GetStringAsync($"/Players/{TwoWayPlayerId}");
+
+        Assert.Contains("href=\"/HallOfFame?year=1936\"", html);
+    }
+
+    [Fact]
+    public async Task PlayerDetails_UnknownPlayer_Returns404()
+    {
+        var response = await Client.GetAsync("/Players/nosuchplayer99");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PlayerDetails_TeamsCard_LinksToFranchisePages()
+    {
+        var html = await GetStringAsync($"/Players/{TwoWayPlayerId}");
+
+        Assert.Contains("href=\"/Teams/Franchise/NYY\"", html);
+
+        var linked = await Client.GetAsync("/Teams/Franchise/NYY");
+        Assert.Equal(HttpStatusCode.OK, linked.StatusCode);
+    }
+
+    [Fact]
+    public async Task PlayerDetails_SeasonRows_LinkToTeamSeasonPages()
+    {
+        var html = await GetStringAsync($"/Players/{TwoWayPlayerId}");
+
+        // Ruth's 1927 Yankees season should link to the team-season page
+        Assert.Contains("href=\"/Teams/Season/NYA/AL/1927\"", html);
+
+        // ... and the linked page must actually resolve
+        var linked = await Client.GetAsync("/Teams/Season/NYA/AL/1927");
+        Assert.Equal(HttpStatusCode.OK, linked.StatusCode);
+    }
+
+    [Fact]
+    public async Task PlayersIndex_StillRoutesToPlayerBrowser()
+    {
+        var response = await Client.GetAsync("/Players");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var html = await response.Content.ReadAsStringAsync();
+        Assert.Contains("id=\"players-content\"", html);
+    }
+
+    [Fact]
+    public async Task PlayerModal_ContainsFullPageLink()
+    {
+        var html = await GetStringAsync($"/Players/Modal/{TwoWayPlayerId}");
+
+        Assert.Contains($"href=\"/Players/{TwoWayPlayerId}\"", html);
+        Assert.Contains("View Full Page", html);
+    }
+
+    [Fact]
+    public async Task PlayerModal_TeamAndSeasonLinksPresent()
+    {
+        var html = await GetStringAsync($"/Players/Modal/{TwoWayPlayerId}");
+
+        Assert.Contains("href=\"/Teams/Franchise/", html);
+        Assert.Contains("href=\"/Teams/Season/", html);
+    }
+}

--- a/baseball-history-tests/Pages/Sprint5SurfaceIntegrationTests.cs
+++ b/baseball-history-tests/Pages/Sprint5SurfaceIntegrationTests.cs
@@ -106,7 +106,7 @@ public class Sprint5SurfaceIntegrationTests(WebApplicationFactory<Program> facto
 
         AssertFullPageShell(html);
         Assert.Contains(">Privacy Policy</h1>", html);
-        Assert.Contains("detail your site's privacy policy", html);
+        Assert.Contains("do not collect, store, sell, or share", html);
     }
 
     [Fact]

--- a/baseball-history-web/Pages/Players/Details.cshtml
+++ b/baseball-history-web/Pages/Players/Details.cshtml
@@ -1,0 +1,78 @@
+@page "/Players/{id}"
+@model baseball_history_web.Pages.Players.DetailsModel
+@{
+    ViewData["Title"] = Model.Player.FullName;
+    var primaryTeamId = Model.Player.Teams.FirstOrDefault()?.TeamId ?? "";
+}
+
+<div id="player-details" data-team="@primaryTeamId">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="/Players">Players</a></li>
+            <li class="breadcrumb-item active" aria-current="page">@Model.Player.FullName</li>
+        </ol>
+    </nav>
+
+    <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-end gap-3 mb-4">
+        <div>
+            <div class="text-uppercase small fw-semibold text-muted mb-2">Player</div>
+            <h1 class="mb-0">
+                @Model.Player.FullName
+                @if (Model.Player.IsInHallOfFame)
+                {
+                    <a class="hof-badge ms-2 text-decoration-none"
+                       href="/HallOfFame?year=@Model.Player.HofInductionYear"
+                       title="View the @Model.Player.HofInductionYear Hall of Fame class">
+                        HOF @Model.Player.HofInductionYear
+                    </a>
+                }
+            </h1>
+        </div>
+    </div>
+
+    <div class="row">
+        @await Html.PartialAsync("_PlayerModalOverview", Model.Player)
+
+        <div class="col-lg-8">
+            @await Html.PartialAsync("_PlayerCareerSummary", Model.Player)
+
+            @if (Model.Player.IsTwoWayPlayer)
+            {
+                <ul class="nav nav-tabs mb-2" id="seasonsTabs-@Model.Player.PlayerId" role="tablist">
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link active" id="batting-tab-@Model.Player.PlayerId" data-bs-toggle="tab"
+                                data-bs-target="#batting-@Model.Player.PlayerId" type="button" role="tab"
+                                aria-controls="batting-@Model.Player.PlayerId" aria-selected="true">
+                            Batting
+                        </button>
+                    </li>
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link" id="pitching-tab-@Model.Player.PlayerId" data-bs-toggle="tab"
+                                data-bs-target="#pitching-@Model.Player.PlayerId" type="button" role="tab"
+                                aria-controls="pitching-@Model.Player.PlayerId" aria-selected="false">
+                            Pitching
+                        </button>
+                    </li>
+                </ul>
+                <div class="tab-content" id="seasonsTabContent-@Model.Player.PlayerId">
+                    <div class="tab-pane fade show active" id="batting-@Model.Player.PlayerId" role="tabpanel"
+                         aria-labelledby="batting-tab-@Model.Player.PlayerId">
+                        @await Html.PartialAsync("_PlayerBattingSeasonsTable", Model.Player)
+                    </div>
+                    <div class="tab-pane fade" id="pitching-@Model.Player.PlayerId" role="tabpanel"
+                         aria-labelledby="pitching-tab-@Model.Player.PlayerId">
+                        @await Html.PartialAsync("_PlayerPitchingSeasonsTable", Model.Player)
+                    </div>
+                </div>
+            }
+            else if (Model.Player.IsPitcher && Model.Player.PitchingSeasons.Any())
+            {
+                @await Html.PartialAsync("_PlayerPitchingSeasonsTable", Model.Player)
+            }
+            else if (Model.Player.BattingSeasons.Any())
+            {
+                @await Html.PartialAsync("_PlayerBattingSeasonsTable", Model.Player)
+            }
+        </div>
+    </div>
+</div>

--- a/baseball-history-web/Pages/Players/Details.cshtml.cs
+++ b/baseball-history-web/Pages/Players/Details.cshtml.cs
@@ -5,10 +5,10 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace baseball_history_web.Pages.Players;
 
-[ResponseCache(Duration = 3600, Location = ResponseCacheLocation.Client)]
-public class ModalModel(PlayerDetailService playerDetailService) : PageModel
+[ResponseCache(Duration = 3600, Location = ResponseCacheLocation.Client, VaryByHeader = "HX-Request")]
+public class DetailsModel(PlayerDetailService playerDetailService) : PageModel
 {
-    public PlayerDetailViewModel? Player { get; set; }
+    public PlayerDetailViewModel Player { get; set; } = null!;
 
     public async Task<IActionResult> OnGetAsync(string id)
     {
@@ -17,13 +17,14 @@ public class ModalModel(PlayerDetailService playerDetailService) : PageModel
             return NotFound();
         }
 
-        Player = await playerDetailService.GetPlayerDetailAsync(id);
+        var player = await playerDetailService.GetPlayerDetailAsync(id);
 
-        if (Player == null)
+        if (player == null)
         {
             return NotFound();
         }
 
-        return Partial("_PlayerModal", Player);
+        Player = player;
+        return Page();
     }
 }

--- a/baseball-history-web/Pages/Players/_PlayerBattingSeasonsTable.cshtml
+++ b/baseball-history-web/Pages/Players/_PlayerBattingSeasonsTable.cshtml
@@ -25,7 +25,19 @@
             {
                 <tr data-team="@season.TeamId">
                     <td>@season.Year</td>
-                    <td>@(season.TeamName ?? season.TeamId)</td>
+                    <td>
+                        @if (!string.IsNullOrEmpty(season.TeamId) && !string.IsNullOrEmpty(season.LgId))
+                        {
+                            <a href="/Teams/Season/@season.TeamId/@season.LgId/@season.Year"
+                               title="View the @season.Year @(season.TeamName ?? season.TeamId) season">
+                                @(season.TeamName ?? season.TeamId)
+                            </a>
+                        }
+                        else
+                        {
+                            @(season.TeamName ?? season.TeamId)
+                        }
+                    </td>
                     <td class="text-end stat-cell">@season.Games</td>
                     <td class="text-end stat-cell">@season.AtBats</td>
                     <td class="text-end stat-cell">@season.Hits</td>

--- a/baseball-history-web/Pages/Players/_PlayerModal.cshtml
+++ b/baseball-history-web/Pages/Players/_PlayerModal.cshtml
@@ -14,7 +14,11 @@
                     @Model.FullName
                     @if (Model.IsInHallOfFame)
                     {
-                        <span class="hof-badge ms-2">HOF @Model.HofInductionYear</span>
+                        <a class="hof-badge ms-2 text-decoration-none"
+                           href="/HallOfFame?year=@Model.HofInductionYear"
+                           title="View the @Model.HofInductionYear Hall of Fame class">
+                            HOF @Model.HofInductionYear
+                        </a>
                     }
                 </h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
@@ -67,6 +71,7 @@
                 </div>
             </div>
             <div class="modal-footer">
+                <a class="btn btn-primary" href="/Players/@Model.PlayerId">View Full Page</a>
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
             </div>
         </div>

--- a/baseball-history-web/Pages/Players/_PlayerModalOverview.cshtml
+++ b/baseball-history-web/Pages/Players/_PlayerModalOverview.cshtml
@@ -81,7 +81,14 @@
                 {
                     <li class="list-group-item d-flex justify-content-between align-items-center"
                         data-team="@team.TeamId">
-                        <span>@(team.TeamName ?? team.TeamId)</span>
+                        @if (!string.IsNullOrEmpty(team.FranchId))
+                        {
+                            <a href="/Teams/Franchise/@team.FranchId">@(team.TeamName ?? team.TeamId)</a>
+                        }
+                        else
+                        {
+                            <span>@(team.TeamName ?? team.TeamId)</span>
+                        }
                         <small class="text-muted">@team.FirstYear-@team.LastYear</small>
                     </li>
                 }
@@ -107,7 +114,11 @@
                 @foreach (var award in Model.Awards.Take(10))
                 {
                     <div class="small mb-1">
-                        <strong>@award.Year</strong> - @award.AwardId (@award.LgId)
+                        <strong>@award.Year</strong> - @award.DisplayName
+                        @if (!string.IsNullOrEmpty(award.LgId))
+                        {
+                            <span class="text-muted">(@award.LgId)</span>
+                        }
                     </div>
                 }
                 @if (Model.Awards.Count > 10)

--- a/baseball-history-web/Pages/Players/_PlayerPitchingSeasonsTable.cshtml
+++ b/baseball-history-web/Pages/Players/_PlayerPitchingSeasonsTable.cshtml
@@ -26,7 +26,19 @@
             {
                 <tr data-team="@season.TeamId">
                     <td>@season.Year</td>
-                    <td>@(season.TeamName ?? season.TeamId)</td>
+                    <td>
+                        @if (!string.IsNullOrEmpty(season.TeamId) && !string.IsNullOrEmpty(season.LgId))
+                        {
+                            <a href="/Teams/Season/@season.TeamId/@season.LgId/@season.Year"
+                               title="View the @season.Year @(season.TeamName ?? season.TeamId) season">
+                                @(season.TeamName ?? season.TeamId)
+                            </a>
+                        }
+                        else
+                        {
+                            @(season.TeamName ?? season.TeamId)
+                        }
+                    </td>
                     <td class="text-end stat-cell">@season.Wins</td>
                     <td class="text-end stat-cell">@season.Losses</td>
                     <td class="text-end stat-cell">@season.FormattedEra</td>

--- a/baseball-history-web/Pages/Shared/_Layout.cshtml
+++ b/baseball-history-web/Pages/Shared/_Layout.cshtml
@@ -67,6 +67,17 @@
                     }
                 }
                 cleanupModals();
+            } else if (evt.detail.target === document.body && document.body.classList.contains('modal-open')) {
+                // Boosted navigation from a link inside an open modal: the swap
+                // replaces the modal markup but leaves the body scroll-lock behind
+                var openModal = document.querySelector('#modal-container .modal');
+                if (openModal) {
+                    var openInstance = bootstrap.Modal.getInstance(openModal);
+                    if (openInstance) {
+                        openInstance.dispose();
+                    }
+                }
+                cleanupModals();
             }
         });
 

--- a/baseball-history-web/Program.cs
+++ b/baseball-history-web/Program.cs
@@ -47,6 +47,7 @@ builder.Services.Configure<GzipCompressionProviderOptions>(options =>
 
 // Add services to the container.
 builder.Services.AddSingleton<TeamColorService>();
+builder.Services.AddScoped<PlayerDetailService>();
 builder.Services.AddHostedService<PlayerCacheService>();
 builder.Services.AddRazorPages();
 builder.Services.AddhtmxRazor();

--- a/baseball-history-web/Services/PlayerDetailService.cs
+++ b/baseball-history-web/Services/PlayerDetailService.cs
@@ -1,0 +1,247 @@
+using baseball_history_web.Models;
+using baseball_history_web.ViewModels;
+using Microsoft.EntityFrameworkCore;
+
+namespace baseball_history_web.Services;
+
+/// <summary>
+/// Loads the full player detail view model (bio, career stats, seasons, teams,
+/// awards). Shared by the player modal and the full player page.
+/// </summary>
+public class PlayerDetailService(BaseballDbContext context)
+{
+    public async Task<PlayerDetailViewModel?> GetPlayerDetailAsync(string id)
+    {
+        var person = await context.People
+            .FirstOrDefaultAsync(p => p.PlayerId == id);
+
+        if (person == null)
+        {
+            return null;
+        }
+
+        var player = PlayerDetailViewModel.FromPeople(person);
+
+        // Check Hall of Fame status
+        var hof = await context.HallOfFame
+            .Where(h => h.PlayerId == id && h.Inducted == "Y")
+            .OrderBy(h => h.Yearid)
+            .FirstOrDefaultAsync();
+
+        if (hof != null)
+        {
+            player.IsInHallOfFame = true;
+            player.HofInductionYear = hof.Yearid;
+        }
+
+        // Get career batting stats - aggregate in database
+        var battingAgg = await context.Batting
+            .Where(b => b.PlayerId == id)
+            .GroupBy(b => b.PlayerId)
+            .Select(g => new
+            {
+                G = g.Sum(b => b.G ?? 0),
+                AB = g.Sum(b => b.Ab ?? 0),
+                R = g.Sum(b => b.R ?? 0),
+                H = g.Sum(b => b.H ?? 0),
+                Doubles = g.Sum(b => b._2b ?? 0),
+                Triples = g.Sum(b => b._3b ?? 0),
+                HR = g.Sum(b => b.Hr ?? 0),
+                BB = g.Sum(b => b.Bb ?? 0),
+                RBI = g.Sum(b => b.Rbi ?? 0),
+                SB = g.Sum(b => b.Sb ?? 0),
+                SO = g.Sum(b => b.So ?? 0)
+            })
+            .FirstOrDefaultAsync();
+
+        if (battingAgg is { AB: > 0 })
+        {
+            player.BattingStats = new CareerBattingStats
+            {
+                Games = battingAgg.G,
+                AtBats = battingAgg.AB,
+                Runs = battingAgg.R,
+                Hits = battingAgg.H,
+                Doubles = battingAgg.Doubles,
+                Triples = battingAgg.Triples,
+                HomeRuns = battingAgg.HR,
+                Walks = battingAgg.BB,
+                Rbi = battingAgg.RBI,
+                StolenBases = battingAgg.SB,
+                Strikeouts = battingAgg.SO
+            };
+        }
+
+        // Get career pitching stats - aggregate in database
+        var pitchingAgg = await context.Pitching
+            .Where(p => p.PlayerId == id)
+            .GroupBy(p => p.PlayerId)
+            .Select(g => new
+            {
+                G = g.Sum(p => p.G ?? 0),
+                GS = g.Sum(p => p.Gs ?? 0),
+                W = g.Sum(p => p.W ?? 0),
+                L = g.Sum(p => p.L ?? 0),
+                SV = g.Sum(p => p.Sv ?? 0),
+                CG = g.Sum(p => p.Cg ?? 0),
+                SHO = g.Sum(p => p.Sho ?? 0),
+                IPOuts = g.Sum(p => p.Ipouts ?? 0),
+                H = g.Sum(p => p.H ?? 0),
+                ER = g.Sum(p => p.Er ?? 0),
+                HR = g.Sum(p => p.Hr ?? 0),
+                BB = g.Sum(p => p.Bb ?? 0),
+                SO = g.Sum(p => p.So ?? 0)
+            })
+            .FirstOrDefaultAsync();
+
+        if (pitchingAgg is { G: > 0 })
+        {
+            player.PitchingStats = new CareerPitchingStats
+            {
+                Games = pitchingAgg.G,
+                GamesStarted = pitchingAgg.GS,
+                Wins = pitchingAgg.W,
+                Losses = pitchingAgg.L,
+                Saves = pitchingAgg.SV,
+                CompleteGames = pitchingAgg.CG,
+                Shutouts = pitchingAgg.SHO,
+                InningsPitched = pitchingAgg.IPOuts / 3.0,
+                Hits = pitchingAgg.H,
+                EarnedRuns = pitchingAgg.ER,
+                HomeRuns = pitchingAgg.HR,
+                Walks = pitchingAgg.BB,
+                Strikeouts = pitchingAgg.SO
+            };
+        }
+
+        // Get season-by-season batting records
+        player.BattingSeasons = await context.Batting
+            .Where(b => b.PlayerId == id)
+            .OrderByDescending(b => b.YearId)
+            .ThenBy(b => b.Stint)
+            .Select(b => new SeasonBattingRecord
+            {
+                Year = b.YearId,
+                TeamId = b.TeamId,
+                TeamName = b.Team.Name,
+                LgId = b.LgId,
+                Games = b.G ?? 0,
+                AtBats = b.Ab ?? 0,
+                Runs = b.R ?? 0,
+                Hits = b.H ?? 0,
+                Doubles = b._2b ?? 0,
+                Triples = b._3b ?? 0,
+                HomeRuns = b.Hr ?? 0
+            })
+            .ToListAsync();
+
+        // Get season-by-season pitching records
+        player.PitchingSeasons = await context.Pitching
+            .Where(p => p.PlayerId == id)
+            .OrderByDescending(p => p.YearId)
+            .ThenBy(p => p.Stint)
+            .Select(p => new SeasonPitchingRecord
+            {
+                Year = p.YearId,
+                TeamId = p.TeamId ?? "",
+                TeamName = p.Team != null ? p.Team.Name : null,
+                LgId = p.LgId ?? "",
+                Games = p.G ?? 0,
+                GamesStarted = p.Gs ?? 0,
+                Wins = p.W ?? 0,
+                Losses = p.L ?? 0,
+                Saves = p.Sv ?? 0,
+                InningsPitched = (p.Ipouts ?? 0) / 3.0,
+                Hits = p.H ?? 0,
+                EarnedRuns = p.Er ?? 0,
+                Strikeouts = p.So ?? 0,
+                Walks = p.Bb ?? 0
+            })
+            .ToListAsync();
+
+        // Get teams played for
+        var teamGroups = await context.Batting
+            .Where(b => b.PlayerId == id)
+            .GroupBy(b => b.TeamId)
+            .Select(g => new
+            {
+                TeamId = g.Key,
+                FirstYear = g.Min(b => b.YearId),
+                LastYear = g.Max(b => b.YearId),
+                Seasons = g.Select(b => b.YearId).Distinct().Count()
+            })
+            .ToListAsync();
+
+        var existingTeamIds = teamGroups.Select(t => t.TeamId).ToHashSet();
+        var pitchingTeams = await context.Pitching
+            .Where(p => p.PlayerId == id && p.TeamId != null && !existingTeamIds.Contains(p.TeamId))
+            .GroupBy(p => p.TeamId!)
+            .Select(g => new
+            {
+                TeamId = g.Key,
+                FirstYear = g.Min(p => p.YearId),
+                LastYear = g.Max(p => p.YearId),
+                Seasons = g.Select(p => p.YearId).Distinct().Count()
+            })
+            .ToListAsync();
+
+        var allTeams = teamGroups
+            .Select(t => new { t.TeamId, t.FirstYear, t.LastYear, t.Seasons })
+            .Concat(pitchingTeams.Select(t => new { t.TeamId, t.FirstYear, t.LastYear, t.Seasons }))
+            .OrderBy(t => t.FirstYear)
+            .ToList();
+
+        // Get team names and franchise ids so team entries can link to franchise pages
+        var teamIds = allTeams.Select(t => t.TeamId).Distinct().ToList();
+        var teamInfo = await context.Teams
+            .Where(t => teamIds.Contains(t.TeamId))
+            .GroupBy(t => t.TeamId)
+            .Select(g => new
+            {
+                TeamId = g.Key,
+                Name = g.OrderByDescending(t => t.YearId).First().Name,
+                FranchId = g.OrderByDescending(t => t.YearId).First().FranchId
+            })
+            .ToDictionaryAsync(t => t.TeamId, t => new { t.Name, t.FranchId });
+
+        player.Teams = allTeams.Select(t => new TeamRecord
+        {
+            TeamId = t.TeamId,
+            TeamName = teamInfo.GetValueOrDefault(t.TeamId)?.Name,
+            FranchId = teamInfo.GetValueOrDefault(t.TeamId)?.FranchId,
+            FirstYear = t.FirstYear,
+            LastYear = t.LastYear,
+            Seasons = t.Seasons
+        }).ToList();
+
+        // Get awards
+        player.Awards = await context.AwardsPlayers
+            .Where(a => a.PlayerId == id)
+            .OrderByDescending(a => a.YearId)
+            .Select(a => new AwardRecord
+            {
+                Year = (short)a.YearId,
+                AwardId = a.AwardId,
+                LgId = a.LgId,
+                Notes = a.Notes
+            })
+            .ToListAsync();
+
+        // Get All-Star appearances
+        var allStarData = await context.AllstarFull
+            .Where(a => a.PlayerId == id)
+            .OrderByDescending(a => a.YearId)
+            .Select(a => new { a.YearId, a.LgId, a.TeamId, a.GameNum })
+            .ToListAsync();
+
+        player.AllStarAppearances = allStarData.Select(a => new AllStarRecord
+        {
+            Year = a.YearId,
+            LgId = a.LgId,
+            TeamId = a.TeamId,
+            GameNum = int.TryParse(a.GameNum, out var gameNum) ? gameNum : 0
+        }).ToList();
+
+        return player;
+    }
+}

--- a/baseball-history-web/ViewModels/PlayerDetailViewModel.cs
+++ b/baseball-history-web/ViewModels/PlayerDetailViewModel.cs
@@ -254,6 +254,29 @@ public class AwardRecord
     public string AwardId { get; set; } = null!;
     public string LgId { get; set; } = null!;
     public string? Notes { get; set; }
+
+    // Lahman award ids are mostly full names already; expand the terse or
+    // abbreviation-style ids so the UI never shows a raw code.
+    private static readonly Dictionary<string, string> FriendlyNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["MVP"] = "Most Valuable Player",
+        ["ROY"] = "Rookie of the Year",
+        ["CYA"] = "Cy Young Award",
+        ["GG"] = "Gold Glove",
+        ["SS"] = "Silver Slugger",
+        ["WS MVP"] = "World Series MVP",
+        ["ALCS MVP"] = "AL Championship Series MVP",
+        ["NLCS MVP"] = "NL Championship Series MVP",
+        ["TSN All-Star"] = "Sporting News All-Star",
+        ["TSN Guide MVP"] = "Sporting News Guide MVP",
+        ["TSN Major League Player of the Year"] = "Sporting News Player of the Year",
+        ["TSN Pitcher of the Year"] = "Sporting News Pitcher of the Year",
+        ["TSN Player of the Year"] = "Sporting News Player of the Year",
+        ["TSN Fireman of the Year"] = "Sporting News Fireman of the Year",
+        ["TSN Reliever of the Year"] = "Sporting News Reliever of the Year"
+    };
+
+    public string DisplayName => FriendlyNames.GetValueOrDefault(AwardId, AwardId);
 }
 
 /// <summary>
@@ -274,6 +297,7 @@ public class TeamRecord
 {
     public string TeamId { get; set; } = null!;
     public string? TeamName { get; set; }
+    public string? FranchId { get; set; }
     public short FirstYear { get; set; }
     public short LastYear { get; set; }
     public int Seasons { get; set; }


### PR DESCRIPTION
Closes #38, closes #39.

## What's in this PR

### Dedicated player pages (#38)
- New canonical, shareable player URL at `/Players/{id}` (e.g. `/Players/ruthba01`) with breadcrumb, HOF badge, bio/career overview, and season-by-season tables — reusing the existing modal partials so there is a single source of truth for the markup.
- Player detail loading extracted from `ModalModel` into a shared `PlayerDetailService`; both the modal and the new page are thin wrappers around it.
- The quick-peek modal is kept and gains a **View Full Page** footer link.
- Unknown player IDs return 404.

### Entity cross-linking (#39)
- Team names in the player overview link to franchise pages (`TeamRecord` now carries `FranchId`).
- Season rows link to the team-season page (`/Teams/Season/{teamId}/{lgId}/{year}`).
- The HOF badge links to that induction year's Hall of Fame class.
- Terse award IDs render friendly names (e.g. "TSN All-Star" → "Sporting News All-Star"); unknown values pass through unchanged.
- Fix: boosted navigation from a link inside an open modal previously left Bootstrap's `modal-open` scroll-lock on the body; the layout cleanup handler now covers that case.

### Test fixes
- 9 new integration tests (`PlayerDetailsPageTests`) covering the page, 404s, modal links, and that linked URLs actually resolve.
- Updated two stale Privacy-page assertions left behind by the policy rewrite in 2c89c71.

## Verification
- Full suite: **398/398 passing** against the real database.
- Live smoke test: Ruth's page renders with working HOF/franchise/season links; Aaron's modal shows the full-page link and friendly award names; `/Players?letter=B` still routes to the player browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)