### PR TITLE
Add active nav, breadcrumbs, and keyboard accessibility

### DIFF
--- a/baseball-history-tests/Pages/NavigationAndAccessibilityTests.cs
+++ b/baseball-history-tests/Pages/NavigationAndAccessibilityTests.cs
@@ -1,0 +1,134 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace baseball_history_tests.Pages;
+
+public class NavigationAndAccessibilityTests(WebApplicationFactory<Program> factory) : IntegrationTestBase(factory)
+{
+    // --- #40: active nav highlighting ---
+
+    [Theory]
+    [InlineData("/Players?letter=A", ">Players</a>")]
+    [InlineData("/Teams", ">Teams</a>")]
+    [InlineData("/Compare", ">Compare</a>")]
+    public async Task Navbar_MarksCurrentSectionActive(string url, string linkText)
+    {
+        var html = await GetStringAsync(url);
+
+        Assert.Contains($"class=\"nav-link active\" aria-current=\"page\"", html);
+        // the active attributes belong to the link for this section
+        var activeIndex = html.IndexOf("class=\"nav-link active\"", StringComparison.Ordinal);
+        var closing = html.IndexOf("</a>", activeIndex, StringComparison.Ordinal) + 4;
+        var anchor = html[activeIndex..closing];
+        Assert.EndsWith(linkText, anchor);
+    }
+
+    [Fact]
+    public async Task Navbar_StatsDropdown_ActiveForHallOfFame()
+    {
+        var html = await GetStringAsync("/HallOfFame");
+
+        Assert.Contains("class=\"nav-link active dropdown-toggle\"", html);
+    }
+
+    [Fact]
+    public async Task Navbar_Home_NotActiveOnOtherPages()
+    {
+        var html = await GetStringAsync("/About");
+
+        var homeAnchor = html.Substring(html.IndexOf(">Home</a>", StringComparison.Ordinal) - 200, 209);
+        Assert.DoesNotContain("nav-link active", homeAnchor);
+    }
+
+    // --- #40: breadcrumbs ---
+
+    [Fact]
+    public async Task Franchise_ShowsBreadcrumbTrail()
+    {
+        var html = await GetStringAsync("/Teams/Franchise/NYY");
+
+        Assert.Contains("aria-label=\"breadcrumb\"", html);
+        Assert.Contains("<a href=\"/Teams\">Teams</a>", html);
+        Assert.Contains("aria-current=\"page\">New York Yankees</li>", html);
+    }
+
+    [Fact]
+    public async Task TeamSeason_ShowsThreeLevelBreadcrumb()
+    {
+        var html = await GetStringAsync("/Teams/Season/NYA/AL/1927");
+
+        Assert.Contains("<a href=\"/Teams\">Teams</a>", html);
+        Assert.Contains("href=\"/Teams/Franchise/NYY\">New York Yankees</a>", html);
+        Assert.Contains("aria-current=\"page\">1927 New York Yankees</li>", html);
+    }
+
+    [Fact]
+    public async Task PlayerDetails_UsesSharedBreadcrumbComponent()
+    {
+        var html = await GetStringAsync("/Players/ruthba01");
+
+        Assert.Contains("<a href=\"/Players\">Players</a>", html);
+        Assert.Contains("aria-current=\"page\">Babe Ruth</li>", html);
+    }
+
+    // --- #41: keyboard accessibility ---
+
+    [Fact]
+    public async Task Layout_HasSkipLinkToMainContent()
+    {
+        var html = await GetStringAsync("/");
+
+        Assert.Contains("class=\"skip-link\" href=\"#main-content\"", html);
+        Assert.Contains("id=\"main-content\"", html);
+    }
+
+    [Fact]
+    public async Task PlayerCards_AreRealAnchorsToPlayerPages()
+    {
+        var html = await GetStringAsync("/Players?letter=A");
+
+        Assert.Contains("<a class=\"card player-card h-100 text-reset text-decoration-none\"", html);
+        Assert.Contains("href=\"/Players/", html);
+    }
+
+    [Fact]
+    public async Task Pagination_ActivePage_HasAriaCurrent()
+    {
+        var html = await GetStringAsync("/Players?letter=A");
+
+        Assert.Contains("aria-current=\"page\"", html);
+        Assert.Contains("href=\"/Players?letter=A&page=2\"", html.Replace("&amp;", "&"));
+    }
+
+    [Fact]
+    public async Task AlphabetNav_Letters_HaveRealHrefs()
+    {
+        var html = await GetStringAsync("/Players?letter=A");
+
+        Assert.Contains("href=\"/Players?letter=B&page=1\"", html.Replace("&amp;", "&"));
+    }
+
+    [Fact]
+    public async Task Leaderboard_SortHeaders_HaveHrefsAndAriaSort()
+    {
+        var html = await GetStringAsync("/Stats/Batting?stat=hr");
+
+        Assert.Contains("aria-sort=\"descending\"", html);
+        Assert.Contains("href=\"/Stats/Batting?stat=g\"", html);
+        Assert.Contains("<caption class=\"visually-hidden\">", html);
+        Assert.Contains("scope=\"col\"", html);
+        Assert.DoesNotContain("href=\"#\"", html);
+    }
+
+    [Theory]
+    [InlineData("/")]
+    [InlineData("/Players?letter=A")]
+    [InlineData("/HallOfFame")]
+    [InlineData("/Stats/Pitching?stat=w")]
+    [InlineData("/Teams/Season/NYA/AL/1927")]
+    public async Task Pages_HaveNoPlaceholderHrefs(string url)
+    {
+        var html = await GetStringAsync(url);
+
+        Assert.DoesNotContain("href=\"#\"", html);
+    }
+}

--- a/baseball-history-tests/Pages/PitchingLeaderboardTests.cs
+++ b/baseball-history-tests/Pages/PitchingLeaderboardTests.cs
@@ -163,8 +163,8 @@ public class PitchingLeaderboardTests(WebApplicationFactory<Program> factory) : 
         var html = await GetHtmxStringAsync("/Stats/Pitching?stat=w&singleSeason=true");
 
         AssertPartialResponse(html);
-        Assert.Contains("<th>Year</th>", html);
-        Assert.Contains("<th>Team</th>", html);
+        Assert.Contains("<th scope=\"col\">Year</th>", html);
+        Assert.Contains("<th scope=\"col\">Team</th>", html);
     }
 
     [Fact]
@@ -173,8 +173,8 @@ public class PitchingLeaderboardTests(WebApplicationFactory<Program> factory) : 
         var html = await GetHtmxStringAsync("/Stats/Pitching?stat=w&singleSeason=false");
 
         AssertPartialResponse(html);
-        Assert.DoesNotContain("<th>Year</th>", html);
-        Assert.DoesNotContain("<th>Team</th>", html);
+        Assert.DoesNotContain("<th scope=\"col\">Year</th>", html);
+        Assert.DoesNotContain("<th scope=\"col\">Team</th>", html);
     }
 
     [Fact]

--- a/baseball-history-web/Pages/Awards/_AwardsList.cshtml
+++ b/baseball-history-web/Pages/Awards/_AwardsList.cshtml
@@ -28,7 +28,7 @@
                     <tr class="@(vote.IsWinner ? "table-success" : "")">
                         <td class="text-end text-muted small">@voteRank</td>
                         <td>
-                            <a href="#" class="text-decoration-none fw-bold"
+                            <a href="/Players/@vote.PlayerId" class="text-decoration-none fw-bold"
                                hx-get="/Players/Modal/@vote.PlayerId"
                                hx-target="#modal-container"
                                hx-swap="innerHTML"
@@ -101,7 +101,7 @@ else
                 {
                     <tr>
                         <td>
-                            <a href="#" class="text-decoration-none fw-bold"
+                            <a href="/Players/@winner.PlayerId" class="text-decoration-none fw-bold"
                                hx-get="/Players/Modal/@winner.PlayerId"
                                hx-target="#modal-container"
                                hx-swap="innerHTML"

--- a/baseball-history-web/Pages/Compare/_ComparePlayerCard.cshtml
+++ b/baseball-history-web/Pages/Compare/_ComparePlayerCard.cshtml
@@ -20,7 +20,7 @@
                 @player.Initials
             </div>
             <h4 class="text-white mb-1">
-                <a href="#" class="text-white text-decoration-none"
+                <a href="/Players/@player.PlayerId" class="text-white text-decoration-none"
                    hx-get="/Players/Modal/@player.PlayerId"
                    hx-target="#modal-container"
                    hx-swap="innerHTML"

--- a/baseball-history-web/Pages/HallOfFame/_InducteeList.cshtml
+++ b/baseball-history-web/Pages/HallOfFame/_InducteeList.cshtml
@@ -34,7 +34,7 @@ else
                 {
                     <tr>
                         <td>
-                            <a href="#" class="text-decoration-none fw-bold"
+                            <a href="/Players/@inductee.PlayerId" class="text-decoration-none fw-bold"
                                hx-get="/Players/Modal/@inductee.PlayerId"
                                hx-target="#modal-container"
                                hx-swap="innerHTML"

--- a/baseball-history-web/Pages/Players/Details.cshtml
+++ b/baseball-history-web/Pages/Players/Details.cshtml
@@ -6,12 +6,9 @@
 }
 
 <div id="player-details" data-team="@primaryTeamId">
-    <nav aria-label="breadcrumb">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="/Players">Players</a></li>
-            <li class="breadcrumb-item active" aria-current="page">@Model.Player.FullName</li>
-        </ol>
-    </nav>
+    @await Html.PartialAsync("Components/_Breadcrumbs", baseball_history_web.ViewModels.BreadcrumbModel.Build(
+        new baseball_history_web.ViewModels.BreadcrumbItem("Players", "/Players"),
+        new baseball_history_web.ViewModels.BreadcrumbItem(Model.Player.FullName)))
 
     <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-end gap-3 mb-4">
         <div>

--- a/baseball-history-web/Pages/Players/_PlayerBattingSeasonsTable.cshtml
+++ b/baseball-history-web/Pages/Players/_PlayerBattingSeasonsTable.cshtml
@@ -6,18 +6,19 @@
     </div>
     <div class="table-responsive" style="max-height: 400px;">
         <table class="table table-sm table-baseball mb-0">
+            <caption class="visually-hidden">Season-by-season batting statistics for @Model.FullName</caption>
             <thead>
             <tr>
-                <th>Year</th>
-                <th>Team</th>
-                <th class="text-end">G</th>
-                <th class="text-end">AB</th>
-                <th class="text-end">H</th>
-                <th class="text-end">2B</th>
-                <th class="text-end">3B</th>
-                <th class="text-end">HR</th>
-                <th class="text-end">R</th>
-                <th class="text-end">AVG</th>
+                <th scope="col">Year</th>
+                <th scope="col">Team</th>
+                <th class="text-end" scope="col">G</th>
+                <th class="text-end" scope="col">AB</th>
+                <th class="text-end" scope="col">H</th>
+                <th class="text-end" scope="col">2B</th>
+                <th class="text-end" scope="col">3B</th>
+                <th class="text-end" scope="col">HR</th>
+                <th class="text-end" scope="col">R</th>
+                <th class="text-end" scope="col">AVG</th>
             </tr>
             </thead>
             <tbody>

--- a/baseball-history-web/Pages/Players/_PlayerPitchingSeasonsTable.cshtml
+++ b/baseball-history-web/Pages/Players/_PlayerPitchingSeasonsTable.cshtml
@@ -6,19 +6,20 @@
     </div>
     <div class="table-responsive" style="max-height: 400px;">
         <table class="table table-sm table-baseball mb-0">
+            <caption class="visually-hidden">Season-by-season pitching statistics for @Model.FullName</caption>
             <thead>
             <tr>
-                <th>Year</th>
-                <th>Team</th>
-                <th class="text-end">W</th>
-                <th class="text-end">L</th>
-                <th class="text-end">ERA</th>
-                <th class="text-end">G</th>
-                <th class="text-end">GS</th>
-                <th class="text-end">SV</th>
-                <th class="text-end">IP</th>
-                <th class="text-end">SO</th>
-                <th class="text-end">BB</th>
+                <th scope="col">Year</th>
+                <th scope="col">Team</th>
+                <th class="text-end" scope="col">W</th>
+                <th class="text-end" scope="col">L</th>
+                <th class="text-end" scope="col">ERA</th>
+                <th class="text-end" scope="col">G</th>
+                <th class="text-end" scope="col">GS</th>
+                <th class="text-end" scope="col">SV</th>
+                <th class="text-end" scope="col">IP</th>
+                <th class="text-end" scope="col">SO</th>
+                <th class="text-end" scope="col">BB</th>
             </tr>
             </thead>
             <tbody>

--- a/baseball-history-web/Pages/Salaries/_SalaryList.cshtml
+++ b/baseball-history-web/Pages/Salaries/_SalaryList.cshtml
@@ -49,7 +49,7 @@ else
                     <tr>
                         <td class="text-end text-muted small">@rank</td>
                         <td>
-                            <a href="#" class="text-decoration-none fw-bold"
+                            <a href="/Players/@entry.PlayerId" class="text-decoration-none fw-bold"
                                hx-get="/Players/Modal/@entry.PlayerId"
                                hx-target="#modal-container"
                                hx-swap="innerHTML"

--- a/baseball-history-web/Pages/Shared/Components/_AlphabetNav.cshtml
+++ b/baseball-history-web/Pages/Shared/Components/_AlphabetNav.cshtml
@@ -11,8 +11,14 @@
         var isActive = Model.CurrentLetter?.ToString().ToUpper() == letter.ToString();
 
         <a class="letter-link @(isActive ? "active" : "") @(!isAvailable ? "disabled" : "")"
+           aria-current="@(isActive ? "page" : null)"
+           @if (!isAvailable)
+           {
+           @:aria-disabled="true"
+           }
            @if (isAvailable && !isActive)
            {
+           @:href="@Model.GetLetterUrl(letter.ToString())"
            @:hx-get="@Model.GetLetterUrl(letter.ToString())"
            @:hx-target="@Model.Target"
            @:hx-swap="innerHTML"

--- a/baseball-history-web/Pages/Shared/Components/_Breadcrumbs.cshtml
+++ b/baseball-history-web/Pages/Shared/Components/_Breadcrumbs.cshtml
@@ -1,0 +1,24 @@
+@* Breadcrumb Component
+   Usage: @await Html.PartialAsync("Components/_Breadcrumbs", BreadcrumbModel.Build(
+       new BreadcrumbItem("Teams", "/Teams"),
+       new BreadcrumbItem("New York Yankees")))
+*@
+
+@model baseball_history_web.ViewModels.BreadcrumbModel
+
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        @foreach (var item in Model.Items)
+        {
+            var isLast = item == Model.Items[^1];
+            if (!isLast && !string.IsNullOrEmpty(item.Url))
+            {
+                <li class="breadcrumb-item"><a href="@item.Url">@item.Label</a></li>
+            }
+            else
+            {
+                <li class="breadcrumb-item active" aria-current="page">@item.Label</li>
+            }
+        }
+    </ol>
+</nav>

--- a/baseball-history-web/Pages/Shared/Components/_Pagination.cshtml
+++ b/baseball-history-web/Pages/Shared/Components/_Pagination.cshtml
@@ -11,6 +11,7 @@
             @* First page *@
             <li class="page-item @(Model.CurrentPage == 1 ? "disabled" : "")">
                 <a class="page-link"
+                   href="@Model.GetPageUrl(1)"
                    hx-get="@Model.GetPageUrl(1)"
                    hx-target="@Model.Target"
                    hx-swap="innerHTML"
@@ -24,6 +25,7 @@
             @* Previous page *@
             <li class="page-item @(Model.CurrentPage == 1 ? "disabled" : "")">
                 <a class="page-link"
+                   href="@Model.GetPageUrl(Model.CurrentPage - 1)"
                    hx-get="@Model.GetPageUrl(Model.CurrentPage - 1)"
                    hx-target="@Model.Target"
                    hx-swap="innerHTML"
@@ -47,6 +49,8 @@
                 {
                     <li class="page-item @(pageNum == Model.CurrentPage ? "active" : "")">
                         <a class="page-link"
+                           aria-current="@(pageNum == Model.CurrentPage ? "page" : null)"
+                           href="@Model.GetPageUrl(pageNum)"
                            hx-get="@Model.GetPageUrl(pageNum)"
                            hx-target="@Model.Target"
                            hx-swap="innerHTML"
@@ -61,6 +65,7 @@
             @* Next page *@
             <li class="page-item @(Model.CurrentPage == Model.TotalPages ? "disabled" : "")">
                 <a class="page-link"
+                   href="@Model.GetPageUrl(Model.CurrentPage + 1)"
                    hx-get="@Model.GetPageUrl(Model.CurrentPage + 1)"
                    hx-target="@Model.Target"
                    hx-swap="innerHTML"
@@ -74,6 +79,7 @@
             @* Last page *@
             <li class="page-item @(Model.CurrentPage == Model.TotalPages ? "disabled" : "")">
                 <a class="page-link"
+                   href="@Model.GetPageUrl(Model.TotalPages)"
                    hx-get="@Model.GetPageUrl(Model.TotalPages)"
                    hx-target="@Model.Target"
                    hx-swap="innerHTML"

--- a/baseball-history-web/Pages/Shared/Components/_PlayerCard.cshtml
+++ b/baseball-history-web/Pages/Shared/Components/_PlayerCard.cshtml
@@ -5,12 +5,13 @@
 @model baseball_history_web.ViewModels.PlayerSummary
 
 <div class="col-md-6 col-lg-4 col-xl-3 mb-4">
-    <div class="card player-card h-100"
-         hx-get="/Players/Modal/@Model.PlayerId"
-         hx-target="#modal-container"
-         hx-swap="innerHTML"
-         hx-boost="false"
-         @(Model.LastTeamId != null ? $"data-team=\"{Model.LastTeamId}\"" : "")>
+    <a class="card player-card h-100 text-reset text-decoration-none"
+       href="/Players/@Model.PlayerId"
+       hx-get="/Players/Modal/@Model.PlayerId"
+       hx-target="#modal-container"
+       hx-swap="innerHTML"
+       hx-boost="false"
+       @(Model.LastTeamId != null ? $"data-team=\"{Model.LastTeamId}\"" : "")>
         <div class="card-img-placeholder">
             @{
                 var initials = "";
@@ -70,5 +71,5 @@
                 </div>
             }
         </div>
-    </div>
+    </a>
 </div>

--- a/baseball-history-web/Pages/Shared/_Layout.cshtml
+++ b/baseball-history-web/Pages/Shared/_Layout.cshtml
@@ -30,10 +30,11 @@
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js" defer></script>
 </head>
 <body hx-boost="true">
+<a class="skip-link" href="#main-content">Skip to main content</a>
 @await Html.PartialAsync("_ShellHeader")
 
 <div class="container mt-4">
-    <main role="main" class="pb-3">
+    <main role="main" class="pb-3" id="main-content">
         @RenderBody()
     </main>
 </div>

--- a/baseball-history-web/Pages/Shared/_ShellHeader.cshtml
+++ b/baseball-history-web/Pages/Shared/_ShellHeader.cshtml
@@ -1,8 +1,28 @@
+@{
+    var currentPage = ViewContext.RouteData.Values["page"] as string ?? "";
+
+    bool IsSection(params string[] prefixes) =>
+        prefixes.Any(p => currentPage.Equals(p, StringComparison.OrdinalIgnoreCase) ||
+                          currentPage.StartsWith(p + "/", StringComparison.OrdinalIgnoreCase));
+
+    string NavClass(bool active) => active ? "nav-link active" : "nav-link";
+    string? AriaCurrent(bool active) => active ? "page" : null;
+
+    var isHome = currentPage.Equals("/Index", StringComparison.OrdinalIgnoreCase);
+    var isAbout = IsSection("/About");
+    var isPlayers = IsSection("/Players");
+    var isTeams = IsSection("/Teams");
+    var isStats = IsSection("/Stats", "/HallOfFame", "/Awards", "/Postseason", "/Salaries");
+    var isCompare = IsSection("/Compare");
+    var isApi = IsSection("/ApiDocs");
+    var isMcp = IsSection("/McpDocs");
+}
+
 <header>
     <nav class="navbar navbar-expand-lg navbar-dark navbar-mlb">
         <div class="container">
             <a class="navbar-brand" asp-area="" asp-page="/Index">
-                <span class="me-2">&#9918;</span>Baseball History
+                <span class="me-2" aria-hidden="true">&#9918;</span>Baseball History
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
                     aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
@@ -11,19 +31,19 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto">
                     <li class="nav-item">
-                        <a class="nav-link" asp-area="" asp-page="/Index">Home</a>
+                        <a class="@NavClass(isHome)" aria-current="@AriaCurrent(isHome)" asp-area="" asp-page="/Index">Home</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" asp-area="" asp-page="/About">About</a>
+                        <a class="@NavClass(isAbout)" aria-current="@AriaCurrent(isAbout)" asp-area="" asp-page="/About">About</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" asp-area="" asp-page="/Players/Index">Players</a>
+                        <a class="@NavClass(isPlayers)" aria-current="@AriaCurrent(isPlayers)" asp-area="" asp-page="/Players/Index">Players</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" asp-area="" asp-page="/Teams/Index">Teams</a>
+                        <a class="@NavClass(isTeams)" aria-current="@AriaCurrent(isTeams)" asp-area="" asp-page="/Teams/Index">Teams</a>
                     </li>
                     <li class="nav-item dropdown">
-                        <button class="nav-link dropdown-toggle" id="statsDropdown"
+                        <button class="@NavClass(isStats) dropdown-toggle" id="statsDropdown"
                                 data-bs-toggle="dropdown" aria-expanded="false">
                             Stats
                         </button>
@@ -40,17 +60,19 @@
                         </ul>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" asp-area="" asp-page="/Compare/Index">Compare</a>
+                        <a class="@NavClass(isCompare)" aria-current="@AriaCurrent(isCompare)" asp-area="" asp-page="/Compare/Index">Compare</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" asp-area="" asp-page="/ApiDocs">API</a>
+                        <a class="@NavClass(isApi)" aria-current="@AriaCurrent(isApi)" asp-area="" asp-page="/ApiDocs">API</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" asp-area="" asp-page="/McpDocs">MCP</a>
+                        <a class="@NavClass(isMcp)" aria-current="@AriaCurrent(isMcp)" asp-area="" asp-page="/McpDocs">MCP</a>
                     </li>
                 </ul>
                 <div class="search-container">
+                    <label for="global-search" class="visually-hidden">Search players and teams</label>
                     <input type="search" class="form-control" placeholder="Search players, teams..."
+                           id="global-search"
                            name="q"
                            hx-get="/Search"
                            hx-trigger="input changed delay:300ms, search"

--- a/baseball-history-web/Pages/Stats/_BattingLeaders.cshtml
+++ b/baseball-history-web/Pages/Stats/_BattingLeaders.cshtml
@@ -13,17 +13,18 @@ else
         </div>
         <div class="table-responsive">
             <table class="table table-baseball table-hover mb-0">
+                <caption class="visually-hidden">@Model.Title</caption>
                 <thead>
                 <tr>
-                    <th class="text-center" style="width: 50px;">Rank</th>
-                    <th>Player</th>
+                    <th class="text-center" style="width: 50px;" scope="col">Rank</th>
+                    <th scope="col">Player</th>
                     @if (Model.SingleSeason)
                     {
-                        <th>Year</th>
-                        <th>Team</th>
+                        <th scope="col">Year</th>
+                        <th scope="col">Team</th>
                     }
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "g" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "g" ? "descending" : null)">
+                        <a href="/Stats/Batting?stat=g" class="text-black text-decoration-none @(Model.StatColumn == "g" ? "fw-bold" : "")"
                            hx-get="/Stats/Batting?stat=g"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -31,8 +32,8 @@ else
                             G @(Model.StatColumn == "g" ? "↓" : "")
                         </a>
                     </th>
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "ab" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "ab" ? "descending" : null)">
+                        <a href="/Stats/Batting?stat=ab" class="text-black text-decoration-none @(Model.StatColumn == "ab" ? "fw-bold" : "")"
                            hx-get="/Stats/Batting?stat=ab"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -40,8 +41,8 @@ else
                             AB @(Model.StatColumn == "ab" ? "↓" : "")
                         </a>
                     </th>
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "h" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "h" ? "descending" : null)">
+                        <a href="/Stats/Batting?stat=h" class="text-black text-decoration-none @(Model.StatColumn == "h" ? "fw-bold" : "")"
                            hx-get="/Stats/Batting?stat=h"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -49,8 +50,8 @@ else
                             H @(Model.StatColumn == "h" ? "↓" : "")
                         </a>
                     </th>
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "2b" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "2b" ? "descending" : null)">
+                        <a href="/Stats/Batting?stat=2b" class="text-black text-decoration-none @(Model.StatColumn == "2b" ? "fw-bold" : "")"
                            hx-get="/Stats/Batting?stat=2b"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -58,8 +59,8 @@ else
                             2B @(Model.StatColumn == "2b" ? "↓" : "")
                         </a>
                     </th>
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "3b" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "3b" ? "descending" : null)">
+                        <a href="/Stats/Batting?stat=3b" class="text-black text-decoration-none @(Model.StatColumn == "3b" ? "fw-bold" : "")"
                            hx-get="/Stats/Batting?stat=3b"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -67,8 +68,8 @@ else
                             3B @(Model.StatColumn == "3b" ? "↓" : "")
                         </a>
                     </th>
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "hr" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "hr" ? "descending" : null)">
+                        <a href="/Stats/Batting?stat=hr" class="text-black text-decoration-none @(Model.StatColumn == "hr" ? "fw-bold" : "")"
                            hx-get="/Stats/Batting?stat=hr"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -76,8 +77,8 @@ else
                             HR @(Model.StatColumn == "hr" ? "↓" : "")
                         </a>
                     </th>
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "rbi" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "rbi" ? "descending" : null)">
+                        <a href="/Stats/Batting?stat=rbi" class="text-black text-decoration-none @(Model.StatColumn == "rbi" ? "fw-bold" : "")"
                            hx-get="/Stats/Batting?stat=rbi"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -85,8 +86,8 @@ else
                             RBI @(Model.StatColumn == "rbi" ? "↓" : "")
                         </a>
                     </th>
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "r" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "r" ? "descending" : null)">
+                        <a href="/Stats/Batting?stat=r" class="text-black text-decoration-none @(Model.StatColumn == "r" ? "fw-bold" : "")"
                            hx-get="/Stats/Batting?stat=r"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -94,8 +95,8 @@ else
                             R @(Model.StatColumn == "r" ? "↓" : "")
                         </a>
                     </th>
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "sb" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "sb" ? "descending" : null)">
+                        <a href="/Stats/Batting?stat=sb" class="text-black text-decoration-none @(Model.StatColumn == "sb" ? "fw-bold" : "")"
                            hx-get="/Stats/Batting?stat=sb"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -103,8 +104,8 @@ else
                             SB @(Model.StatColumn == "sb" ? "↓" : "")
                         </a>
                     </th>
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "bb" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "bb" ? "descending" : null)">
+                        <a href="/Stats/Batting?stat=bb" class="text-black text-decoration-none @(Model.StatColumn == "bb" ? "fw-bold" : "")"
                            hx-get="/Stats/Batting?stat=bb"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -112,8 +113,8 @@ else
                             BB @(Model.StatColumn == "bb" ? "↓" : "")
                         </a>
                     </th>
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "avg" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "avg" ? "descending" : null)">
+                        <a href="/Stats/Batting?stat=avg" class="text-black text-decoration-none @(Model.StatColumn == "avg" ? "fw-bold" : "")"
                            hx-get="/Stats/Batting?stat=avg"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -121,8 +122,8 @@ else
                             AVG @(Model.StatColumn == "avg" ? "↓" : "")
                         </a>
                     </th>
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "ops" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "ops" ? "descending" : null)">
+                        <a href="/Stats/Batting?stat=ops" class="text-black text-decoration-none @(Model.StatColumn == "ops" ? "fw-bold" : "")"
                            hx-get="/Stats/Batting?stat=ops"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -138,7 +139,7 @@ else
                     <tr data-team="@leader.TeamId">
                         <td class="text-center rank-cell">@leader.Rank</td>
                         <td>
-                            <a href="#" class="text-decoration-none"
+                            <a href="/Players/@leader.PlayerId" class="text-decoration-none"
                                hx-get="/Players/Modal/@leader.PlayerId"
                                hx-target="#modal-container"
                                hx-swap="innerHTML"

--- a/baseball-history-web/Pages/Stats/_PitchingLeaders.cshtml
+++ b/baseball-history-web/Pages/Stats/_PitchingLeaders.cshtml
@@ -13,17 +13,18 @@ else
         </div>
         <div class="table-responsive">
             <table class="table table-baseball table-hover mb-0">
+                <caption class="visually-hidden">@Model.Title</caption>
                 <thead>
                 <tr>
-                    <th class="text-center" style="width: 50px;">Rank</th>
-                    <th>Player</th>
+                    <th class="text-center" style="width: 50px;" scope="col">Rank</th>
+                    <th scope="col">Player</th>
                     @if (Model.SingleSeason)
                     {
-                        <th>Year</th>
-                        <th>Team</th>
+                        <th scope="col">Year</th>
+                        <th scope="col">Team</th>
                     }
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "g" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "g" ? "descending" : null)">
+                        <a href="/Stats/Pitching?stat=g" class="text-black text-decoration-none @(Model.StatColumn == "g" ? "fw-bold" : "")"
                            hx-get="/Stats/Pitching?stat=g"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -31,8 +32,8 @@ else
                             G @Html.Raw(Model.StatColumn == "g" ? "↓" : "")
                         </a>
                     </th>
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "gs" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "gs" ? "descending" : null)">
+                        <a href="/Stats/Pitching?stat=gs" class="text-black text-decoration-none @(Model.StatColumn == "gs" ? "fw-bold" : "")"
                            hx-get="/Stats/Pitching?stat=gs"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -40,8 +41,8 @@ else
                             GS @Html.Raw(Model.StatColumn == "gs" ? "↓" : "")
                         </a>
                     </th>
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "w" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "w" ? "descending" : null)">
+                        <a href="/Stats/Pitching?stat=w" class="text-black text-decoration-none @(Model.StatColumn == "w" ? "fw-bold" : "")"
                            hx-get="/Stats/Pitching?stat=w"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -49,8 +50,8 @@ else
                             W @Html.Raw(Model.StatColumn == "w" ? "↓" : "")
                         </a>
                     </th>
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "l" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "l" ? "descending" : null)">
+                        <a href="/Stats/Pitching?stat=l" class="text-black text-decoration-none @(Model.StatColumn == "l" ? "fw-bold" : "")"
                            hx-get="/Stats/Pitching?stat=l"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -58,8 +59,8 @@ else
                             L @Html.Raw(Model.StatColumn == "l" ? "↑" : "")
                         </a>
                     </th>
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "sv" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "sv" ? "descending" : null)">
+                        <a href="/Stats/Pitching?stat=sv" class="text-black text-decoration-none @(Model.StatColumn == "sv" ? "fw-bold" : "")"
                            hx-get="/Stats/Pitching?stat=sv"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -67,8 +68,8 @@ else
                             SV @Html.Raw(Model.StatColumn == "sv" ? "↓" : "")
                         </a>
                     </th>
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "ip" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "ip" ? "descending" : null)">
+                        <a href="/Stats/Pitching?stat=ip" class="text-black text-decoration-none @(Model.StatColumn == "ip" ? "fw-bold" : "")"
                            hx-get="/Stats/Pitching?stat=ip"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -76,8 +77,8 @@ else
                             IP @Html.Raw(Model.StatColumn == "ip" ? "↓" : "")
                         </a>
                     </th>
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "so" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "so" ? "descending" : null)">
+                        <a href="/Stats/Pitching?stat=so" class="text-black text-decoration-none @(Model.StatColumn == "so" ? "fw-bold" : "")"
                            hx-get="/Stats/Pitching?stat=so"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -85,8 +86,8 @@ else
                             SO @Html.Raw(Model.StatColumn == "so" ? "↓" : "")
                         </a>
                     </th>
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "bb" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "bb" ? "descending" : null)">
+                        <a href="/Stats/Pitching?stat=bb" class="text-black text-decoration-none @(Model.StatColumn == "bb" ? "fw-bold" : "")"
                            hx-get="/Stats/Pitching?stat=bb"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -94,8 +95,8 @@ else
                             BB @Html.Raw(Model.StatColumn == "bb" ? "↑" : "")
                         </a>
                     </th>
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "era" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "era" ? "descending" : null)">
+                        <a href="/Stats/Pitching?stat=era" class="text-black text-decoration-none @(Model.StatColumn == "era" ? "fw-bold" : "")"
                            hx-get="/Stats/Pitching?stat=era"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -103,8 +104,8 @@ else
                             ERA @Html.Raw(Model.StatColumn == "era" ? "↑" : "")
                         </a>
                     </th>
-                    <th class="text-end">
-                        <a href="#" class="text-black text-decoration-none @(Model.StatColumn == "whip" ? "fw-bold" : "")"
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "whip" ? "descending" : null)">
+                        <a href="/Stats/Pitching?stat=whip" class="text-black text-decoration-none @(Model.StatColumn == "whip" ? "fw-bold" : "")"
                            hx-get="/Stats/Pitching?stat=whip"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
@@ -120,7 +121,7 @@ else
                     <tr data-team="@leader.TeamId">
                         <td class="text-center rank-cell">@leader.Rank</td>
                         <td>
-                            <a href="#" class="text-decoration-none"
+                            <a href="/Players/@leader.PlayerId" class="text-decoration-none"
                                hx-get="/Players/Modal/@leader.PlayerId"
                                hx-target="#modal-container"
                                hx-swap="innerHTML"

--- a/baseball-history-web/Pages/Teams/Franchise.cshtml
+++ b/baseball-history-web/Pages/Teams/Franchise.cshtml
@@ -1,7 +1,15 @@
 @page "{id}"
+@using baseball_history_web.ViewModels
 @model baseball_history_web.Pages.Teams.FranchiseModel
 @{
     ViewData["Title"] = Model.ViewModel.Franchise?.FranchiseName ?? "Franchise";
+}
+
+@if (Model.ViewModel.Franchise != null)
+{
+    @await Html.PartialAsync("Components/_Breadcrumbs", BreadcrumbModel.Build(
+        new BreadcrumbItem("Teams", "/Teams"),
+        new BreadcrumbItem(Model.ViewModel.Franchise.FranchiseName)))
 }
 
 <div id="franchise-content">

--- a/baseball-history-web/Pages/Teams/Season.cshtml
+++ b/baseball-history-web/Pages/Teams/Season.cshtml
@@ -1,7 +1,20 @@
 @page "{teamId}/{lgId}/{year:int}"
+@using baseball_history_web.ViewModels
 @model baseball_history_web.Pages.Teams.SeasonModel
 @{
     ViewData["Title"] = Model.Team != null ? $"{Model.Team.TeamName} {Model.Team.Year}" : "Team Season";
+}
+
+@if (Model.Team != null)
+{
+    var franchiseCrumb = !string.IsNullOrEmpty(Model.Team.FranchiseId)
+        ? new BreadcrumbItem(Model.Team.FranchiseName ?? Model.Team.FranchiseId, $"/Teams/Franchise/{Model.Team.FranchiseId}")
+        : new BreadcrumbItem(Model.Team.TeamName);
+
+    @await Html.PartialAsync("Components/_Breadcrumbs", BreadcrumbModel.Build(
+        new BreadcrumbItem("Teams", "/Teams"),
+        franchiseCrumb,
+        new BreadcrumbItem($"{Model.Team.Year} {Model.Team.TeamName}")))
 }
 
 @if (Model.Team == null)

--- a/baseball-history-web/Pages/Teams/_TeamSeason.cshtml
+++ b/baseball-history-web/Pages/Teams/_TeamSeason.cshtml
@@ -105,7 +105,7 @@
                         {
                             <li class="list-group-item d-flex justify-content-between align-items-center">
                                 <span>
-                                    <a href="#" class="text-decoration-none"
+                                    <a href="/Players/@manager.PlayerId" class="text-decoration-none"
                                        hx-get="/Players/Modal/@manager.PlayerId"
                                        hx-target="#modal-container"
                                        hx-swap="innerHTML"
@@ -151,7 +151,7 @@
                             {
                                 <tr>
                                     <td>
-                                        <a href="#" class="text-decoration-none"
+                                        <a href="/Players/@batter.PlayerId" class="text-decoration-none"
                                            hx-get="/Players/Modal/@batter.PlayerId"
                                            hx-target="#modal-container"
                                            hx-swap="innerHTML"
@@ -203,7 +203,7 @@
                             {
                                 <tr>
                                     <td>
-                                        <a href="#" class="text-decoration-none"
+                                        <a href="/Players/@pitcher.PlayerId" class="text-decoration-none"
                                            hx-get="/Players/Modal/@pitcher.PlayerId"
                                            hx-target="#modal-container"
                                            hx-swap="innerHTML"

--- a/baseball-history-web/Pages/_HomeLeaderboards.cshtml
+++ b/baseball-history-web/Pages/_HomeLeaderboards.cshtml
@@ -12,7 +12,7 @@
                     <li class="list-group-item d-flex justify-content-between align-items-center">
                         <span>
                             <span class="badge bg-secondary me-2">@leader.Rank</span>
-                            <a href="#" class="text-decoration-none"
+                            <a href="/Players/@leader.PlayerId" class="text-decoration-none"
                                hx-get="/Players/Modal/@leader.PlayerId"
                                hx-target="#modal-container"
                                hx-swap="innerHTML"
@@ -45,7 +45,7 @@
                     <li class="list-group-item d-flex justify-content-between align-items-center">
                         <span>
                             <span class="badge bg-secondary me-2">@leader.Rank</span>
-                            <a href="#" class="text-decoration-none"
+                            <a href="/Players/@leader.PlayerId" class="text-decoration-none"
                                hx-get="/Players/Modal/@leader.PlayerId"
                                hx-target="#modal-container"
                                hx-swap="innerHTML"

--- a/baseball-history-web/Pages/_HomeRecentHallOfFamers.cshtml
+++ b/baseball-history-web/Pages/_HomeRecentHallOfFamers.cshtml
@@ -25,7 +25,7 @@
                                 @initials.ToUpper()
                             </div>
                             <div>
-                                <a href="#" class="text-decoration-none fw-bold"
+                                <a href="/Players/@player.PlayerId" class="text-decoration-none fw-bold"
                                    hx-get="/Players/Modal/@player.PlayerId"
                                    hx-target="#modal-container"
                                    hx-swap="innerHTML"

--- a/baseball-history-web/Pages/_SearchResults.cshtml
+++ b/baseball-history-web/Pages/_SearchResults.cshtml
@@ -46,13 +46,13 @@ else
     }
 
     <div class="px-3 py-2 text-center border-top">
-        <a href="#" class="small text-decoration-none"
-           hx-get="/Search?handler=AllResults&q=@Uri.EscapeDataString(Model.Query)"
-           hx-target="#modal-container"
-           hx-swap="innerHTML"
-           hx-boost="false"
-           onclick="setTimeout(function() { document.getElementById('search-results').innerHTML = ''; }, 0);">
+        <button type="button" class="btn btn-link btn-sm small text-decoration-none p-0"
+                hx-get="/Search?handler=AllResults&q=@Uri.EscapeDataString(Model.Query)"
+                hx-target="#modal-container"
+                hx-swap="innerHTML"
+                hx-boost="false"
+                onclick="setTimeout(function() { document.getElementById('search-results').innerHTML = ''; }, 0);">
             View all results for "@Model.Query"
-        </a>
+        </button>
     </div>
 }

--- a/baseball-history-web/ViewModels/BreadcrumbModel.cs
+++ b/baseball-history-web/ViewModels/BreadcrumbModel.cs
@@ -1,0 +1,15 @@
+namespace baseball_history_web.ViewModels;
+
+/// <summary>
+/// Breadcrumb trail for drill-down pages. The last item is rendered as the
+/// current page (no link).
+/// </summary>
+public class BreadcrumbModel
+{
+    public List<BreadcrumbItem> Items { get; set; } = new();
+
+    public static BreadcrumbModel Build(params BreadcrumbItem[] items) =>
+        new() { Items = items.ToList() };
+}
+
+public record BreadcrumbItem(string Label, string? Url = null);

--- a/baseball-history-web/wwwroot/css/site.css
+++ b/baseball-history-web/wwwroot/css/site.css
@@ -676,3 +676,22 @@ a:hover {
         font-size: 0.875rem;
     }
 }
+
+/* Skip-to-content link: hidden until keyboard-focused */
+.skip-link {
+    position: absolute;
+    top: -100px;
+    left: 0.5rem;
+    z-index: 2000;
+    padding: 0.5rem 1rem;
+    background: var(--mlb-navy);
+    color: #fff;
+    border-radius: 0 0 0.375rem 0.375rem;
+    text-decoration: none;
+    transition: top 0.15s ease-in-out;
+}
+
+.skip-link:focus {
+    top: 0;
+    color: #fff;
+}

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -394,8 +394,19 @@ Shell lifecycle JavaScript is intentionally inline in `Pages/Shared/_Layout.csht
 ## Accessibility
 
 - Semantic HTML elements
+- Skip-to-content link (`.skip-link` in `_Layout.cshtml`, visually hidden until focused)
 - ARIA labels on interactive elements
-- Keyboard navigation support
+- Every htmx-triggered link carries a real `href` mirroring its `hx-get` URL, so
+  keyboard activation, middle-click, and open-in-new-tab all work. Player cards
+  are anchors: normal click opens the quick-view modal via htmx, while
+  middle-click/new-tab lands on the full `/Players/{id}` page.
+- `aria-current="page"` marks the active navbar section, pagination page, and
+  alphabet-nav letter; the navbar computes its active state from the current
+  Razor Pages route.
+- Sortable leaderboard headers set `aria-sort="descending"` on the active column.
+- Stat tables have visually hidden `<caption>`s and `scope="col"` on header cells.
+- Actions that are not navigation (e.g. "View all results" in the search
+  dropdown) are `<button>`s, not `href="#"` anchors.
 - Sufficient color contrast
 - Focus indicators
 


### PR DESCRIPTION
Closes #40, closes #41.

## Active nav + breadcrumbs (#40)
- `_ShellHeader` computes the active section from the current Razor Pages route and applies `.active` + `aria-current="page"` — including the Stats dropdown toggle when on Batting/Pitching/HOF/Awards/Postseason/Salaries.
- New shared `_Breadcrumbs` component (+ `BreadcrumbModel`), rendered on:
  - `/Teams/Franchise/{id}` → Teams → Franchise
  - `/Teams/Season/{teamId}/{lgId}/{year}` → Teams → Franchise → Year Team
  - `/Players/{id}` → Players → Player (replaces the inline breadcrumb from #38)
- Decorative navbar baseball glyph marked `aria-hidden`.

## Keyboard accessibility (#41)
- **Skip-to-content link** in `_Layout`, visually hidden until keyboard-focused (`.skip-link` styles in `site.css`).
- **Player cards are real anchors**: Enter/middle-click/open-in-new-tab lands on the full `/Players/{id}` page, while a normal click still opens the quick-view modal via htmx.
- **`href="#"` eliminated app-wide** (home leaderboards, HOF list, awards, salaries, team rosters, compare card, leaderboard sort headers): every htmx link now carries a real href mirroring its `hx-get`, so middle-click and no-JS degrade sensibly.
- Alphabet-nav letters gained real hrefs (they previously had none at all — keyboard-dead), plus `aria-current` on the active letter and `aria-disabled` on empty ones.
- Pagination links gained real hrefs and `aria-current="page"` on the active page.
- Leaderboards: `aria-sort="descending"` on the active column, visually hidden `<caption>`, `scope="col"` on all header cells (also applied to player season tables).
- Global search input now has a visually hidden label; the search dropdown's "View all results" action is a `<button>` instead of an anchor.
- `docs/FRONTEND.md` accessibility section updated to describe what's actually implemented.

## Verification
- 18 new integration tests (`NavigationAndAccessibilityTests`) covering active nav per section, breadcrumb trails, skip link, card anchors, pagination/alphabet hrefs + aria-current, aria-sort, and a no-`href="#"` sweep across key pages.
- Full suite: **416/416 passing** against the real database.
- Live smoke test confirmed active nav on Players/HOF, the three-level season breadcrumb, skip link, card anchors, and sort headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)