### PR TITLE
Add filters and sorting to Players and Teams browsers

### DIFF
--- a/baseball-history-tests/Pages/BrowserFilterTests.cs
+++ b/baseball-history-tests/Pages/BrowserFilterTests.cs
@@ -1,0 +1,127 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace baseball_history_tests.Pages;
+
+public class BrowserFilterTests(WebApplicationFactory<Program> factory) : IntegrationTestBase(factory)
+{
+    // --- #42: Players browser filters ---
+
+    [Fact]
+    public async Task Players_NameFilter_SearchesAcrossAllLetters()
+    {
+        var html = await GetStringAsync("/Players?q=babe+ruth");
+
+        Assert.Contains("Babe Ruth", html);
+        Assert.Contains("id=\"player-filter-form\"", html);
+    }
+
+    [Fact]
+    public async Task Players_PositionFilter_ReturnsResults()
+    {
+        var html = await GetStringAsync("/Players?letter=A&pos=P");
+
+        Assert.Contains("player-card", html);
+        Assert.Contains("value=\"P\" selected", html);
+    }
+
+    [Fact]
+    public async Task Players_EraFilter_ReturnsPlayersActiveInDecade()
+    {
+        var html = await GetStringAsync("/Players?q=babe+ruth&era=1920");
+
+        Assert.Contains("Babe Ruth", html);
+
+        // Ruth was not active in the 1950s
+        var html2 = await GetStringAsync("/Players?q=babe+ruth&era=1950");
+        Assert.DoesNotContain("player-card", html2);
+    }
+
+    [Fact]
+    public async Task Players_SortByHomeRuns_PutsSluggerFirst()
+    {
+        var html = await GetStringAsync("/Players?letter=A&sort=hr");
+
+        var firstCard = html.IndexOf("player-card", StringComparison.Ordinal);
+        Assert.True(firstCard >= 0);
+        var cardRegion = html.Substring(firstCard, 2000);
+        Assert.Contains("Hank Aaron", cardRegion);
+    }
+
+    [Fact]
+    public async Task Players_Pagination_PreservesFilters()
+    {
+        var html = (await GetStringAsync("/Players?letter=A&pos=P")).Replace("&amp;", "&");
+
+        Assert.Contains("pos=P", html);
+        Assert.Contains("letter=A", html);
+    }
+
+    [Fact]
+    public async Task Players_AlphabetNav_PreservesNonSearchFilters()
+    {
+        var html = (await GetStringAsync("/Players?letter=A&pos=C")).Replace("&amp;", "&");
+
+        // letter links keep the position filter
+        Assert.Contains("/Players?pos=C&letter=B", html);
+    }
+
+    [Fact]
+    public async Task Players_DefaultView_UnaffectedByFilterPlumbing()
+    {
+        var html = await GetStringAsync("/Players");
+
+        Assert.Contains("id=\"players-content\"", html);
+        Assert.Contains("id=\"player-filter-form\"", html);
+        Assert.Contains("class=\"alphabet-nav\"", html);
+    }
+
+    // --- #43: Teams browser filters ---
+
+    [Fact]
+    public async Task Teams_NameFilter_MatchesFranchiseName()
+    {
+        var html = await GetStringAsync("/Teams?q=yankees");
+
+        Assert.Contains("New York Yankees", html);
+        Assert.DoesNotContain("Boston Red Sox", html);
+    }
+
+    [Fact]
+    public async Task Teams_NameFilter_WithLeague_Compose()
+    {
+        var html = await GetStringAsync("/Teams?league=AL&q=sox");
+
+        Assert.Contains("Red Sox", html);
+        Assert.Contains("White Sox", html);
+        Assert.DoesNotContain("Yankees", html);
+        Assert.Contains("name=\"league\" value=\"AL\"", html);
+    }
+
+    [Fact]
+    public async Task Teams_EraFilter_ShowsFranchisesActiveInDecade()
+    {
+        var html = await GetStringAsync("/Teams?era=1880");
+
+        // 1880s-only franchises qualify, modern-only expansion teams do not
+        Assert.Contains("Historical Franchises", html);
+        Assert.DoesNotContain("Arizona Diamondbacks", html);
+    }
+
+    [Fact]
+    public async Task Teams_FilterForm_PresentOnFullPage()
+    {
+        var html = await GetStringAsync("/Teams");
+
+        Assert.Contains("id=\"team-filter-form\"", html);
+        Assert.Contains("id=\"team-search\"", html);
+        Assert.Contains("id=\"team-era\"", html);
+    }
+
+    [Fact]
+    public async Task Teams_LeagueButtons_PreserveFiltersInUrls()
+    {
+        var html = (await GetStringAsync("/Teams?q=sox&era=1990")).Replace("&amp;", "&");
+
+        Assert.Contains("/Teams?league=AL&q=sox&era=1990", html);
+    }
+}

--- a/baseball-history-tests/Pages/PageRoutingIntegrationTests.cs
+++ b/baseball-history-tests/Pages/PageRoutingIntegrationTests.cs
@@ -223,17 +223,21 @@ public class PageRoutingIntegrationTests(WebApplicationFactory<Program> factory)
         var html = await GetStringAsync("/Teams");
 
         AssertFullPageShell(html);
+        Assert.Contains("id=\"teams-content\"", html);
         Assert.Contains("id=\"team-list\"", html);
-        Assert.Contains("Teams & Franchises", html);
+        Assert.Contains("Teams &amp; Franchises", html);
     }
 
     [Fact]
-    public async Task Teams_NonBoostedHtmx_ReturnsTeamListPartialOnly()
+    public async Task Teams_NonBoostedHtmx_ReturnsTeamsContentPartialOnly()
     {
         var html = await GetHtmxStringAsync("/Teams?league=AL");
 
         AssertPartialResponse(html);
-        Assert.DoesNotContain("id=\"team-list\"", html);
+        // the partial swaps into #teams-content, so it contains the list host but not the outer shell
+        Assert.DoesNotContain("id=\"teams-content\"", html);
+        Assert.Contains("id=\"team-list\"", html);
+        Assert.Contains("id=\"team-filter-form\"", html);
         Assert.Contains("Active Franchises", html);
         Assert.DoesNotContain("<rhx-badge", html);
     }

--- a/baseball-history-web/Pages/Players/Index.cshtml.cs
+++ b/baseball-history-web/Pages/Players/Index.cshtml.cs
@@ -17,10 +17,19 @@ public class IndexModel(BaseballDbContext context, IMemoryCache cache) : PageMod
 
     public PlayerListViewModel ViewModel { get; set; } = new();
 
-    public async Task<IActionResult> OnGetAsync(string? letter, [FromQuery] int page = 1)
+    public async Task<IActionResult> OnGetAsync(string? letter, [FromQuery] int page = 1,
+        [FromQuery] string? q = null, [FromQuery] string? pos = null,
+        [FromQuery] int? era = null, [FromQuery] string? sort = null)
     {
+        var sortBy = PlayerListViewModel.SortOptions.Any(o => o.Value == sort) ? sort! : "name";
+        var searchQuery = string.IsNullOrWhiteSpace(q) ? null : q.Trim();
+        var position = PlayerListViewModel.PositionOptions.Any(o => o.Value == pos) ? pos : null;
+        var eraDecade = era is >= 1870 and <= 2030 ? era - era % 10 : null;
+        var hasFilters = searchQuery != null || position != null || eraDecade.HasValue || sortBy != "name";
+
         // Serve from pre-warmed cache for the default view (letter A, page 1, full page load)
-        var isDefaultRequest = (letter == null || letter.Equals("A", StringComparison.OrdinalIgnoreCase)) && page <= 1;
+        var isDefaultRequest = (letter == null || letter.Equals("A", StringComparison.OrdinalIgnoreCase)) &&
+                               page <= 1 && !hasFilters;
         if (isDefaultRequest && !Request.IsHtmxNonBoostedRequest())
         {
             var cached = PlayerCacheService.GetCachedFirstPage(cache);
@@ -30,6 +39,11 @@ public class IndexModel(BaseballDbContext context, IMemoryCache cache) : PageMod
                 return Page();
             }
         }
+
+        ViewModel.SearchQuery = searchQuery;
+        ViewModel.Position = position;
+        ViewModel.Era = eraDecade;
+        ViewModel.SortBy = sortBy;
 
         // Get all available first letters (cached)
         ViewModel.AvailableLetters = (await cache.GetOrCreateAsync("player_letters", async entry =>
@@ -47,9 +61,9 @@ public class IndexModel(BaseballDbContext context, IMemoryCache cache) : PageMod
                 .ToList();
         }))!;
 
-        // Default to 'A' if no letter specified
+        // Default to 'A' if no letter specified; a name search spans all letters
         var currentLetter = letter?.ToUpper().FirstOrDefault() ?? 'A';
-        ViewModel.CurrentLetter = currentLetter.ToString();
+        ViewModel.CurrentLetter = searchQuery == null ? currentLetter.ToString() : null;
 
         // Get Hall of Fame player IDs for highlighting (cached)
         var hofPlayerIds = (await cache.GetOrCreateAsync("hof_player_ids", async entry =>
@@ -62,11 +76,41 @@ public class IndexModel(BaseballDbContext context, IMemoryCache cache) : PageMod
                 .ToHashSetAsync();
         }))!;
 
-        // Query players by last name starting letter
-        var query = context.People
-            .Where(p => p.NameLast != null && p.NameLast.ToUpper().StartsWith(currentLetter.ToString()))
-            .OrderBy(p => p.NameLast)
-            .ThenBy(p => p.NameFirst);
+        // Name search spans all players; otherwise browse by last-name letter
+        var query = searchQuery != null
+            ? context.People.Where(p =>
+                ((p.NameFirst ?? "") + " " + (p.NameLast ?? "")).ToLower().Contains(searchQuery.ToLower()))
+            : context.People.Where(p =>
+                p.NameLast != null && p.NameLast.ToUpper().StartsWith(currentLetter.ToString()));
+
+        if (position != null)
+        {
+            query = position == "OF"
+                ? query.Where(p => p.Fieldings.Any(f =>
+                    f.Pos == "OF" || f.Pos == "LF" || f.Pos == "CF" || f.Pos == "RF"))
+                : query.Where(p => p.Fieldings.Any(f => f.Pos == position));
+        }
+
+        if (eraDecade.HasValue)
+        {
+            // Active at any point during the decade
+            var eraStart = new DateOnly(eraDecade.Value, 1, 1);
+            var eraEnd = new DateOnly(eraDecade.Value + 9, 12, 31);
+            query = query.Where(p => p.Debut != null && p.FinalGame != null &&
+                                     p.Debut <= eraEnd && p.FinalGame >= eraStart);
+        }
+
+        query = sortBy switch
+        {
+            "hr" => query.OrderByDescending(p => p.Battings.Sum(b => (int?)b.Hr) ?? 0)
+                .ThenBy(p => p.NameLast).ThenBy(p => p.NameFirst),
+            "hits" => query.OrderByDescending(p => p.Battings.Sum(b => (int?)b.H) ?? 0)
+                .ThenBy(p => p.NameLast).ThenBy(p => p.NameFirst),
+            "games" => query.OrderByDescending(p =>
+                    (p.Battings.Sum(b => (int?)b.G) ?? 0) + (p.Pitchings.Sum(pi => (int?)pi.G) ?? 0))
+                .ThenBy(p => p.NameLast).ThenBy(p => p.NameFirst),
+            _ => query.OrderBy(p => p.NameLast).ThenBy(p => p.NameFirst)
+        };
 
         // Get total count for pagination
         ViewModel.TotalPlayers = await query.CountAsync();

--- a/baseball-history-web/Pages/Players/_PlayerList.cshtml
+++ b/baseball-history-web/Pages/Players/_PlayerList.cshtml
@@ -6,7 +6,7 @@
 }
 else
 {
-    var queryParams = new Dictionary<string, string>();
+    var queryParams = Model.FilterQueryParams();
     if (!string.IsNullOrEmpty(Model.CurrentLetter))
     {
         queryParams["letter"] = Model.CurrentLetter;

--- a/baseball-history-web/Pages/Players/_PlayersContent.cshtml
+++ b/baseball-history-web/Pages/Players/_PlayersContent.cshtml
@@ -2,12 +2,84 @@
 
 @await Html.PartialAsync("_PlayersHeader", Model)
 
+<form id="player-filter-form" class="row g-2 mb-3" onsubmit="return false;">
+    <input type="hidden" name="letter" value="@Model.CurrentLetter"/>
+    <div class="col-md-4">
+        <label for="player-search" class="visually-hidden">Filter players by name</label>
+        <input type="search" class="form-control" id="player-search" name="q"
+               placeholder="Filter by name..." value="@Model.SearchQuery" autocomplete="off"
+               hx-get="/Players"
+               hx-include="#player-filter-form"
+               hx-target="#players-content"
+               hx-swap="innerHTML"
+               hx-push-url="true"
+               hx-trigger="input changed delay:300ms, search"/>
+    </div>
+    <div class="col-6 col-md-2">
+        <label for="player-position" class="visually-hidden">Position</label>
+        <select class="form-select" id="player-position" name="pos"
+                hx-get="/Players"
+                hx-include="#player-filter-form"
+                hx-target="#players-content"
+                hx-swap="innerHTML"
+                hx-push-url="true">
+            <option value="">All Positions</option>
+            @foreach (var (value, label) in baseball_history_web.ViewModels.PlayerListViewModel.PositionOptions)
+            {
+                <option value="@value" selected="@(Model.Position == value)">@label</option>
+            }
+        </select>
+    </div>
+    <div class="col-6 col-md-2">
+        <label for="player-era" class="visually-hidden">Era</label>
+        <select class="form-select" id="player-era" name="era"
+                hx-get="/Players"
+                hx-include="#player-filter-form"
+                hx-target="#players-content"
+                hx-swap="innerHTML"
+                hx-push-url="true">
+            <option value="">All Eras</option>
+            @foreach (var decade in baseball_history_web.ViewModels.PlayerListViewModel.EraOptions)
+            {
+                <option value="@decade" selected="@(Model.Era == decade)">@(decade)s</option>
+            }
+        </select>
+    </div>
+    <div class="col-6 col-md-2">
+        <label for="player-sort" class="visually-hidden">Sort by</label>
+        <select class="form-select" id="player-sort" name="sort"
+                hx-get="/Players"
+                hx-include="#player-filter-form"
+                hx-target="#players-content"
+                hx-swap="innerHTML"
+                hx-push-url="true">
+            @foreach (var (value, label) in baseball_history_web.ViewModels.PlayerListViewModel.SortOptions)
+            {
+                <option value="@value" selected="@(Model.SortBy == value)">Sort: @label</option>
+            }
+        </select>
+    </div>
+    @if (Model.HasActiveFilters)
+    {
+        <div class="col-6 col-md-2">
+            <a class="btn btn-outline-secondary w-100" href="/Players?letter=@(Model.CurrentLetter ?? "A")"
+               hx-get="/Players?letter=@(Model.CurrentLetter ?? "A")"
+               hx-target="#players-content"
+               hx-swap="innerHTML"
+               hx-push-url="true">
+                Clear Filters
+            </a>
+        </div>
+    }
+</form>
+
 @await Html.PartialAsync("Components/_AlphabetNav", new baseball_history_web.ViewModels.AlphabetNavModel
 {
     CurrentLetter = Model.CurrentLetter?.FirstOrDefault(),
     AvailableLetters = Model.AvailableLetters,
     BaseUrl = "/Players",
-    Target = "#players-content"
+    Target = "#players-content",
+    QueryParams = Model.FilterQueryParams(includeSearch: false)
 })
 
 <div id="player-list">

--- a/baseball-history-web/Pages/Teams/Index.cshtml
+++ b/baseball-history-web/Pages/Teams/Index.cshtml
@@ -4,33 +4,8 @@
     ViewData["Title"] = "Teams";
 }
 
-<div class="d-flex justify-content-between align-items-center mb-4">
-    <h1 class="text-mlb-navy mb-0">Teams & Franchises</h1>
-    <div class="d-flex gap-2">
-        <a href="/Teams"
-           class="btn btn-sm @(Model.ViewModel.SelectedLeague == null ? "btn-primary" : "btn-outline-primary")"
-           hx-get="/Teams"
-           hx-target="#team-list"
-           hx-push-url="true">
-            All
-        </a>
-        <a href="/Teams?league=AL"
-           class="btn btn-sm @(Model.ViewModel.SelectedLeague == "AL" ? "btn-primary" : "btn-outline-primary")"
-           hx-get="/Teams?league=AL"
-           hx-target="#team-list"
-           hx-push-url="true">
-            AL
-        </a>
-        <a href="/Teams?league=NL"
-           class="btn btn-sm @(Model.ViewModel.SelectedLeague == "NL" ? "btn-primary" : "btn-outline-primary")"
-           hx-get="/Teams?league=NL"
-           hx-target="#team-list"
-           hx-push-url="true">
-            NL
-        </a>
-    </div>
-</div>
+<h1 class="text-mlb-navy mb-4">Teams &amp; Franchises</h1>
 
-<div id="team-list">
-    @await Html.PartialAsync("_TeamList", Model.ViewModel)
+<div id="teams-content">
+    @await Html.PartialAsync("_TeamsContent", Model.ViewModel)
 </div>

--- a/baseball-history-web/Pages/Teams/Index.cshtml.cs
+++ b/baseball-history-web/Pages/Teams/Index.cshtml.cs
@@ -12,9 +12,12 @@ public class IndexModel(BaseballDbContext context) : PageModel
 {
     public TeamListViewModel ViewModel { get; set; } = new();
 
-    public async Task<IActionResult> OnGetAsync(string? league)
+    public async Task<IActionResult> OnGetAsync(string? league, [FromQuery] string? q = null,
+        [FromQuery] int? era = null)
     {
         ViewModel.SelectedLeague = league;
+        ViewModel.SearchQuery = string.IsNullOrWhiteSpace(q) ? null : q.Trim();
+        ViewModel.Era = era is >= 1870 and <= 2030 ? era - era % 10 : null;
 
         // Aggregate team stats in the database instead of loading all 2700+ team records
         var summaries = await context.TeamsFranchises
@@ -43,6 +46,16 @@ public class IndexModel(BaseballDbContext context) : PageModel
             if (!string.IsNullOrEmpty(league) && summary.CurrentLeague != league)
                 continue;
 
+            // Name filter
+            if (ViewModel.SearchQuery != null &&
+                !summary.FranchiseName.Contains(ViewModel.SearchQuery, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            // Era filter: franchise fielded a team at some point during the decade
+            if (ViewModel.Era.HasValue &&
+                !(summary.FirstYear <= ViewModel.Era.Value + 9 && summary.LastYear >= ViewModel.Era.Value))
+                continue;
+
             if (summary.IsActive)
                 ViewModel.ActiveFranchises.Add(summary);
             else
@@ -55,7 +68,7 @@ public class IndexModel(BaseballDbContext context) : PageModel
 
         if (Request.IsHtmxNonBoostedRequest())
         {
-            return Partial("_TeamList", ViewModel);
+            return Partial("_TeamsContent", ViewModel);
         }
 
         return Page();

--- a/baseball-history-web/Pages/Teams/Season.cshtml
+++ b/baseball-history-web/Pages/Teams/Season.cshtml
@@ -9,7 +9,7 @@
 {
     var franchiseCrumb = !string.IsNullOrEmpty(Model.Team.FranchiseId)
         ? new BreadcrumbItem(Model.Team.FranchiseName ?? Model.Team.FranchiseId, $"/Teams/Franchise/{Model.Team.FranchiseId}")
-        : new BreadcrumbItem(Model.Team.TeamName);
+        : new BreadcrumbItem(Model.Team.TeamName ?? Model.Team.TeamId);
 
     @await Html.PartialAsync("Components/_Breadcrumbs", BreadcrumbModel.Build(
         new BreadcrumbItem("Teams", "/Teams"),

--- a/baseball-history-web/Pages/Teams/_TeamsContent.cshtml
+++ b/baseball-history-web/Pages/Teams/_TeamsContent.cshtml
@@ -1,0 +1,95 @@
+@model baseball_history_web.ViewModels.TeamListViewModel
+
+@{
+    string LeagueUrl(string? league)
+    {
+        var parts = new List<string>();
+        if (league != null) parts.Add($"league={league}");
+        if (!string.IsNullOrEmpty(Model.SearchQuery)) parts.Add($"q={Uri.EscapeDataString(Model.SearchQuery)}");
+        if (Model.Era.HasValue) parts.Add($"era={Model.Era}");
+        return "/Teams" + (parts.Count > 0 ? "?" + string.Join("&", parts) : "");
+    }
+}
+
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-3">
+    <span class="text-muted">@Model.TotalFranchises franchises</span>
+    <div class="d-flex gap-2" role="group" aria-label="Filter by league">
+        <a href="@LeagueUrl(null)"
+           class="btn btn-sm @(Model.SelectedLeague == null ? "btn-primary" : "btn-outline-primary")"
+           aria-current="@(Model.SelectedLeague == null ? "true" : null)"
+           hx-get="@LeagueUrl(null)"
+           hx-target="#teams-content"
+           hx-swap="innerHTML"
+           hx-push-url="true">
+            All
+        </a>
+        <a href="@LeagueUrl("AL")"
+           class="btn btn-sm @(Model.SelectedLeague == "AL" ? "btn-primary" : "btn-outline-primary")"
+           aria-current="@(Model.SelectedLeague == "AL" ? "true" : null)"
+           hx-get="@LeagueUrl("AL")"
+           hx-target="#teams-content"
+           hx-swap="innerHTML"
+           hx-push-url="true">
+            AL
+        </a>
+        <a href="@LeagueUrl("NL")"
+           class="btn btn-sm @(Model.SelectedLeague == "NL" ? "btn-primary" : "btn-outline-primary")"
+           aria-current="@(Model.SelectedLeague == "NL" ? "true" : null)"
+           hx-get="@LeagueUrl("NL")"
+           hx-target="#teams-content"
+           hx-swap="innerHTML"
+           hx-push-url="true">
+            NL
+        </a>
+    </div>
+</div>
+
+<form id="team-filter-form" class="row g-2 mb-4" onsubmit="return false;">
+    @if (!string.IsNullOrEmpty(Model.SelectedLeague))
+    {
+        <input type="hidden" name="league" value="@Model.SelectedLeague"/>
+    }
+    <div class="col-md-4">
+        <label for="team-search" class="visually-hidden">Filter franchises by name</label>
+        <input type="search" class="form-control" id="team-search" name="q"
+               placeholder="Filter by name..." value="@Model.SearchQuery" autocomplete="off"
+               hx-get="/Teams"
+               hx-include="#team-filter-form"
+               hx-target="#teams-content"
+               hx-swap="innerHTML"
+               hx-push-url="true"
+               hx-trigger="input changed delay:300ms, search"/>
+    </div>
+    <div class="col-6 col-md-3">
+        <label for="team-era" class="visually-hidden">Era</label>
+        <select class="form-select" id="team-era" name="era"
+                hx-get="/Teams"
+                hx-include="#team-filter-form"
+                hx-target="#teams-content"
+                hx-swap="innerHTML"
+                hx-push-url="true">
+            <option value="">All Eras</option>
+            @foreach (var decade in baseball_history_web.ViewModels.TeamListViewModel.EraOptions)
+            {
+                <option value="@decade" selected="@(Model.Era == decade)">@(decade)s</option>
+            }
+        </select>
+    </div>
+    @if (Model.HasActiveFilters)
+    {
+        <div class="col-6 col-md-2">
+            <a class="btn btn-outline-secondary w-100"
+               href="@(Model.SelectedLeague != null ? $"/Teams?league={Model.SelectedLeague}" : "/Teams")"
+               hx-get="@(Model.SelectedLeague != null ? $"/Teams?league={Model.SelectedLeague}" : "/Teams")"
+               hx-target="#teams-content"
+               hx-swap="innerHTML"
+               hx-push-url="true">
+                Clear Filters
+            </a>
+        </div>
+    }
+</form>
+
+<div id="team-list">
+    @await Html.PartialAsync("_TeamList", Model)
+</div>

--- a/baseball-history-web/ViewModels/PlayerListViewModel.cs
+++ b/baseball-history-web/ViewModels/PlayerListViewModel.cs
@@ -14,6 +14,55 @@ public class PlayerListViewModel
     public int TotalPlayers { get; set; }
     public int PageSize { get; set; } = 50;
     public List<char> AvailableLetters { get; set; } = new();
+
+    // Filters (issue #42)
+    public string? SearchQuery { get; set; }
+    public string? Position { get; set; }
+    public int? Era { get; set; }
+    public string SortBy { get; set; } = "name";
+
+    public bool HasActiveFilters => !string.IsNullOrWhiteSpace(SearchQuery) ||
+                                    !string.IsNullOrEmpty(Position) ||
+                                    Era.HasValue ||
+                                    SortBy != "name";
+
+    public static readonly IReadOnlyList<(string Value, string Label)> PositionOptions = new[]
+    {
+        ("P", "Pitcher"),
+        ("C", "Catcher"),
+        ("1B", "First Base"),
+        ("2B", "Second Base"),
+        ("3B", "Third Base"),
+        ("SS", "Shortstop"),
+        ("OF", "Outfield"),
+        ("DH", "Designated Hitter")
+    };
+
+    public static readonly IReadOnlyList<(string Value, string Label)> SortOptions = new[]
+    {
+        ("name", "Name"),
+        ("hr", "Home Runs"),
+        ("hits", "Hits"),
+        ("games", "Games")
+    };
+
+    // Decades from the first professional season through today
+    public static IEnumerable<int> EraOptions =>
+        Enumerable.Range(0, (DateTime.UtcNow.Year - 1870) / 10 + 1).Select(i => 1870 + i * 10);
+
+    /// <summary>
+    /// Non-default filter values as query params, used to keep filters sticky
+    /// across pagination and alphabet navigation.
+    /// </summary>
+    public Dictionary<string, string> FilterQueryParams(bool includeSearch = true)
+    {
+        var p = new Dictionary<string, string>();
+        if (includeSearch && !string.IsNullOrWhiteSpace(SearchQuery)) p["q"] = SearchQuery;
+        if (!string.IsNullOrEmpty(Position)) p["pos"] = Position;
+        if (Era.HasValue) p["era"] = Era.Value.ToString();
+        if (SortBy != "name") p["sort"] = SortBy;
+        return p;
+    }
 }
 
 /// <summary>

--- a/baseball-history-web/ViewModels/TeamListViewModel.cs
+++ b/baseball-history-web/ViewModels/TeamListViewModel.cs
@@ -10,6 +10,17 @@ public class TeamListViewModel
     public List<FranchiseSummary> ActiveFranchises { get; set; } = new();
     public List<FranchiseSummary> InactiveFranchises { get; set; } = new();
     public string? SelectedLeague { get; set; }
+
+    // Filters (issue #43)
+    public string? SearchQuery { get; set; }
+    public int? Era { get; set; }
+
+    public bool HasActiveFilters => !string.IsNullOrWhiteSpace(SearchQuery) || Era.HasValue;
+
+    public int TotalFranchises => ActiveFranchises.Count + InactiveFranchises.Count;
+
+    // Decades from the first professional season through today
+    public static IEnumerable<int> EraOptions => PlayerListViewModel.EraOptions;
 }
 
 /// <summary>


### PR DESCRIPTION
Closes #42, closes #43.

## Players browser (#42)
- **Name filter**: debounced (300ms) htmx search box; a non-empty query searches across *all* players, not just the current letter.
- **Position filter**: P/C/1B/2B/3B/SS/OF/DH (OF matches LF/CF/RF/OF appearances in the Fielding table). Semantics are "ever appeared at position".
- **Era filter**: decade selects (1870s–2020s), matching players active at any point during the decade (debut ≤ decade end AND final game ≥ decade start).
- **Sort**: name (default), career HR, hits, or games — pushed down to the database as ordered subquery sums.
- Filters stay sticky across pagination and alphabet navigation (letter links keep position/era/sort but drop the name query, since picking a letter exits search mode). A Clear Filters button appears when any filter is active.
- The pre-warmed default cache (letter A, page 1) is only served when no filters are active.

## Teams browser (#43)
- **Name filter** and **era select** composing with the existing All/AL/NL league buttons; the league buttons now carry active filters in their URLs.
- The page moves to a `#teams-content` swap target containing buttons + filter bar + list — the same pattern the Players browser uses — so filter state re-renders consistently on every update.
- Franchise count shown in the toolbar.

All new controls follow the conventions from #41: real hrefs on filter-clearing links, visually hidden labels on inputs, `aria-current` on the league toggle.

## Verification
- 12 new integration tests (`BrowserFilterTests`) covering cross-letter search, position/era filtering (including a negative case: Ruth doesn't match the 1950s era), HR sort ordering (Hank Aaron first for letter A), filter-preserving pagination/alphabet/league URLs, and filter-form rendering.
- Two existing Teams tests updated for the new partial shape (`_TeamsContent` wraps `#team-list`).
- Full suite: **428/428 passing**. Live smoke test: `q=griffey` finds both Griffeys in ~0.2s, `letter=A&sort=hr` puts Hank Aaron first, `SS + 1990s` and Teams `q=sox` / `era=1880&league=NL` all return correct results.
- Also fixes a `CS8604` nullability warning in the Season page breadcrumb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)