### PR TITLE
Add branded error pages, dark mode, and loading feedback

### DIFF
--- a/baseball-history-tests/Pages/ErrorPagesAndPolishTests.cs
+++ b/baseball-history-tests/Pages/ErrorPagesAndPolishTests.cs
@@ -1,0 +1,110 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace baseball_history_tests.Pages;
+
+public class ErrorPagesAndPolishTests(WebApplicationFactory<Program> factory) : IntegrationTestBase(factory)
+{
+    // --- #44: custom 404 / error pages ---
+
+    [Fact]
+    public async Task UnknownRoute_ReturnsBranded404Page()
+    {
+        var response = await Client.GetAsync("/this-page-does-not-exist");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        var html = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Swing and a Miss!", html);
+        Assert.Contains("href=\"/Players\"", html);
+        Assert.Contains("href=\"/HallOfFame\"", html);
+    }
+
+    [Fact]
+    public async Task UnknownPlayer_ReturnsBranded404Page()
+    {
+        var response = await Client.GetAsync("/Players/nosuchplayer999");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        var html = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Swing and a Miss!", html);
+    }
+
+    [Fact]
+    public async Task ApiUnknownRoute_StaysBodylessFor404()
+    {
+        var response = await Client.GetAsync("/api/players/nosuchplayer999");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.DoesNotContain("Swing and a Miss!", body);
+    }
+
+    [Fact]
+    public async Task ErrorPage_IsFriendly_WithoutDevModeText()
+    {
+        var html = await GetStringAsync("/Error");
+
+        Assert.Contains("Rain Delay", html);
+        Assert.DoesNotContain("Development Mode", html);
+        Assert.DoesNotContain("ASPNETCORE_ENVIRONMENT", html);
+    }
+
+    // --- #45: dark mode ---
+
+    [Fact]
+    public async Task Layout_AppliesThemeBeforeFirstPaint()
+    {
+        var html = await GetStringAsync("/");
+
+        Assert.Contains("bb-theme", html);
+        Assert.Contains("prefers-color-scheme: dark", html);
+        Assert.Contains("data-bs-theme", html);
+    }
+
+    [Fact]
+    public async Task Navbar_HasThemeToggle()
+    {
+        var html = await GetStringAsync("/");
+
+        Assert.Contains("id=\"theme-toggle\"", html);
+        Assert.Contains("aria-label=\"Toggle dark mode\"", html);
+    }
+
+    [Fact]
+    public async Task SiteCss_ContainsDarkThemeOverrides()
+    {
+        var css = await GetStringAsync("/css/site.css");
+
+        Assert.Contains("[data-bs-theme=\"dark\"]", css);
+        Assert.Contains(".theme-icon-dark", css);
+    }
+
+    // --- #46: loading feedback ---
+
+    [Fact]
+    public async Task PlayersPage_HasLoadingIndicatorWiring()
+    {
+        var html = await GetStringAsync("/Players");
+
+        Assert.Contains("hx-indicator=\"#players-loading\"", html);
+        Assert.Contains("id=\"players-loading\"", html);
+    }
+
+    [Fact]
+    public async Task TeamsPage_HasLoadingIndicatorWiring()
+    {
+        var html = await GetStringAsync("/Teams");
+
+        Assert.Contains("hx-indicator=\"#teams-loading\"", html);
+        Assert.Contains("id=\"teams-loading\"", html);
+    }
+
+    [Fact]
+    public async Task Layout_HasModalLoadingOverlay()
+    {
+        var html = await GetStringAsync("/");
+
+        Assert.Contains("id=\"modal-loading\"", html);
+        Assert.Contains("modal-loading-overlay", html);
+    }
+}

--- a/baseball-history-tests/Pages/PageRoutingIntegrationTests.cs
+++ b/baseball-history-tests/Pages/PageRoutingIntegrationTests.cs
@@ -174,7 +174,7 @@ public class PageRoutingIntegrationTests(WebApplicationFactory<Program> factory)
     [InlineData("/McpDocs", ">MCP Server</h1>", "search_players")]
     [InlineData("/Privacy", ">Privacy Policy</h1>", "do not collect, store, sell, or share")]
     [InlineData("/Health", ">Health Check</h1>", "Database Status")]
-    [InlineData("/Error", ">Error</h1>", "Development Mode")]
+    [InlineData("/Error", ">Rain Delay</h1>", "went wrong on our end")]
     public async Task SupportPages_FullPage_RenderWithinShell(string route, string headingMarker, string contentMarker)
     {
         var html = await GetStringAsync(route);

--- a/baseball-history-tests/Pages/Sprint5SurfaceIntegrationTests.cs
+++ b/baseball-history-tests/Pages/Sprint5SurfaceIntegrationTests.cs
@@ -130,8 +130,8 @@ public class Sprint5SurfaceIntegrationTests(WebApplicationFactory<Program> facto
         var html = await response.Content.ReadAsStringAsync();
 
         AssertFullPageShell(html);
-        Assert.Contains(">Error</h1>", html);
-        Assert.Contains("An error occurred while processing your request.", html);
+        Assert.Contains(">Rain Delay</h1>", html);
+        Assert.Contains("went wrong on our end", html);
         Assert.True(response.Headers.CacheControl?.NoStore, "Expected /Error to be marked no-store.");
     }
 

--- a/baseball-history-web/Pages/Error.cshtml
+++ b/baseball-history-web/Pages/Error.cshtml
@@ -1,42 +1,28 @@
-﻿@page
+@page
 @model ErrorModel
 @{
     ViewData["Title"] = "Error";
 }
 
-@await Html.PartialAsync("Components/_PageHeader", new baseball_history_web.ViewModels.PageHeaderModel
-{
-    Title = "Error",
-    Subtitle = "An error occurred while processing your request.",
-    Eyebrow = "Support",
-    BadgeText = "Attention",
-    BadgeVariant = "warning"
-})
+<div class="text-center py-5">
+    <div style="font-size: 5rem;" aria-hidden="true">&#9918;</div>
+    <h1 class="text-mlb-navy mt-3">Rain Delay</h1>
+    <p class="lead text-muted">
+        Something went wrong on our end while processing your request.
+        Please try again in a moment.
+    </p>
 
-<div class="card border-0 shadow-sm">
-    <div class="card-body p-4">
-        <div class="alert alert-danger" role="alert">
-            An error occurred while processing your request.
-        </div>
-
-        @if (Model.ShowRequestId)
-        {
-            <p>
-                <strong>Request ID:</strong> <code>@Model.RequestId</code>
-            </p>
-        }
-
-        <h3>Development Mode</h3>
-        <p>
-            Swapping to the <strong>Development</strong> environment displays detailed information about the error that
-            occurred.
+    @if (Model.ShowRequestId)
+    {
+        <p class="text-muted small">
+            If the problem persists, mention this request ID:
+            <code>@Model.RequestId</code>
         </p>
-        <p class="mb-0">
-            <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
-            It can result in displaying sensitive information from exceptions to end users.
-            For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong>
-            environment variable to <strong>Development</strong>
-            and restarting the app.
-        </p>
+    }
+
+    <div class="d-flex flex-wrap justify-content-center gap-2 mt-4">
+        <a class="btn btn-primary" href="/">Home</a>
+        <a class="btn btn-outline-primary" href="/Players">Players</a>
+        <a class="btn btn-outline-primary" href="/Teams">Teams</a>
     </div>
 </div>

--- a/baseball-history-web/Pages/NotFound.cshtml
+++ b/baseball-history-web/Pages/NotFound.cshtml
@@ -1,0 +1,29 @@
+@page
+@model baseball_history_web.Pages.NotFoundModel
+@{
+    ViewData["Title"] = "Page Not Found";
+}
+
+<div class="text-center py-5">
+    <div style="font-size: 5rem;" aria-hidden="true">&#9918;</div>
+    <h1 class="text-mlb-navy mt-3">Swing and a Miss!</h1>
+    <p class="lead text-muted">
+        @if (Model.ErrorStatusCode == 404)
+        {
+            @:We couldn't find that page. It may have been traded, retired, or never called up.
+        }
+        else
+        {
+            @:Something went wrong handling that request (status @Model.ErrorStatusCode).
+        }
+    </p>
+    <p class="text-muted">Try the search box above, or head back to one of these:</p>
+
+    <div class="d-flex flex-wrap justify-content-center gap-2 mt-4">
+        <a class="btn btn-primary" href="/">Home</a>
+        <a class="btn btn-outline-primary" href="/Players">Players</a>
+        <a class="btn btn-outline-primary" href="/Teams">Teams</a>
+        <a class="btn btn-outline-primary" href="/Stats/Batting">Batting Leaders</a>
+        <a class="btn btn-outline-primary" href="/HallOfFame">Hall of Fame</a>
+    </div>
+</div>

--- a/baseball-history-web/Pages/NotFound.cshtml.cs
+++ b/baseball-history-web/Pages/NotFound.cshtml.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace baseball_history_web.Pages;
+
+[ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+public class NotFoundModel : PageModel
+{
+    public int ErrorStatusCode { get; set; } = 404;
+
+    public void OnGet()
+    {
+        // Reached via UseStatusCodePagesWithReExecute, which preserves the
+        // original status code on the response.
+        ErrorStatusCode = HttpContext.Response.StatusCode;
+    }
+}

--- a/baseball-history-web/Pages/Players/Index.cshtml
+++ b/baseball-history-web/Pages/Players/Index.cshtml
@@ -4,6 +4,12 @@
     ViewData["Title"] = "Players";
 }
 
-<div id="players-content">
-    @await Html.PartialAsync("_PlayersContent", Model.ViewModel)
+@* hx-indicator is inherited by every htmx control inside (filters, alphabet nav, pagination) *@
+<div class="position-relative" hx-indicator="#players-loading">
+    <div id="players-loading" class="htmx-indicator loading-overlay">
+        @await Html.PartialAsync("Components/_LoadingSpinner", "Loading players...")
+    </div>
+    <div id="players-content">
+        @await Html.PartialAsync("_PlayersContent", Model.ViewModel)
+    </div>
 </div>

--- a/baseball-history-web/Pages/Shared/_Layout.cshtml
+++ b/baseball-history-web/Pages/Shared/_Layout.cshtml
@@ -8,6 +8,16 @@
     <link rel="icon" type="image/svg+xml" href="~/favicon.svg"/>
     <link rel="icon" type="image/x-icon" href="~/favicon.ico"/>
     <script type="importmap"></script>
+    <script>
+        // Apply the saved (or OS-preferred) theme before first paint to avoid a flash
+        (function () {
+            var theme = localStorage.getItem('bb-theme');
+            if (theme !== 'dark' && theme !== 'light') {
+                theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            }
+            document.documentElement.setAttribute('data-bs-theme', theme);
+        })();
+    </script>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css"/>
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true"/>
     <link rel="stylesheet" href="~/css/team-colors.css" asp-append-version="true"/>
@@ -40,6 +50,9 @@
 </div>
 
 <div id="modal-container"></div>
+<div id="modal-loading" class="modal-loading-overlay">
+    @await Html.PartialAsync("Components/_LoadingSpinner", "Loading player...")
+</div>
 
 @await Html.PartialAsync("_ShellFooter")
 
@@ -136,6 +149,35 @@
 
         window.addEventListener('beforeunload', function() {
             cleanupModals();
+        });
+
+        // Show a loading overlay while any modal content is being fetched
+        function setModalLoading(on) {
+            var overlay = document.getElementById('modal-loading');
+            if (overlay) overlay.classList.toggle('show', on);
+        }
+
+        document.addEventListener('htmx:beforeRequest', function (evt) {
+            if (evt.detail.target && evt.detail.target.id === 'modal-container') {
+                setModalLoading(true);
+            }
+        });
+
+        ['htmx:afterRequest', 'htmx:sendError', 'htmx:responseError', 'htmx:timeout'].forEach(function (name) {
+            document.addEventListener(name, function (evt) {
+                if (evt.detail.target && evt.detail.target.id === 'modal-container') {
+                    setModalLoading(false);
+                }
+            });
+        });
+
+        // Theme toggle (button lives in the navbar, delegated so it survives hx-boost swaps)
+        document.addEventListener('click', function (e) {
+            var toggle = e.target.closest('#theme-toggle');
+            if (!toggle) return;
+            var next = document.documentElement.getAttribute('data-bs-theme') === 'dark' ? 'light' : 'dark';
+            document.documentElement.setAttribute('data-bs-theme', next);
+            localStorage.setItem('bb-theme', next);
         });
     }
 </script>

--- a/baseball-history-web/Pages/Shared/_ShellHeader.cshtml
+++ b/baseball-history-web/Pages/Shared/_ShellHeader.cshtml
@@ -69,6 +69,11 @@
                         <a class="@NavClass(isMcp)" aria-current="@AriaCurrent(isMcp)" asp-area="" asp-page="/McpDocs">MCP</a>
                     </li>
                 </ul>
+                <button type="button" id="theme-toggle" class="btn btn-link nav-link me-2 theme-toggle"
+                        aria-label="Toggle dark mode" title="Toggle dark mode">
+                    <span class="theme-icon-light" aria-hidden="true">&#9728;</span>
+                    <span class="theme-icon-dark" aria-hidden="true">&#9789;</span>
+                </button>
                 <div class="search-container">
                     <label for="global-search" class="visually-hidden">Search players and teams</label>
                     <input type="search" class="form-control" placeholder="Search players, teams..."

--- a/baseball-history-web/Pages/Teams/Index.cshtml
+++ b/baseball-history-web/Pages/Teams/Index.cshtml
@@ -6,6 +6,12 @@
 
 <h1 class="text-mlb-navy mb-4">Teams &amp; Franchises</h1>
 
-<div id="teams-content">
-    @await Html.PartialAsync("_TeamsContent", Model.ViewModel)
+@* hx-indicator is inherited by every htmx control inside (filters, league buttons) *@
+<div class="position-relative" hx-indicator="#teams-loading">
+    <div id="teams-loading" class="htmx-indicator loading-overlay">
+        @await Html.PartialAsync("Components/_LoadingSpinner", "Loading teams...")
+    </div>
+    <div id="teams-content">
+        @await Html.PartialAsync("_TeamsContent", Model.ViewModel)
+    </div>
 </div>

--- a/baseball-history-web/Program.cs
+++ b/baseball-history-web/Program.cs
@@ -65,6 +65,12 @@ if (!app.Environment.IsDevelopment())
     app.UseHsts();
 }
 
+// Branded 404 (and other error-status) page for browser routes; re-execute
+// preserves the URL and status code. REST API responses stay bodyless.
+app.UseWhen(
+    ctx => !ctx.Request.Path.StartsWithSegments("/api"),
+    branch => branch.UseStatusCodePagesWithReExecute("/NotFound"));
+
 app.UseHttpsRedirection();
 app.UseResponseCompression();
 app.UsehtmxRazor();

--- a/baseball-history-web/wwwroot/css/site.css
+++ b/baseball-history-web/wwwroot/css/site.css
@@ -695,3 +695,116 @@ a:hover {
     top: 0;
     color: #fff;
 }
+
+/* --------------------------------------------------------------------------
+   Dark Mode (issue #45)
+   Bootstrap 5.3 handles its own components via data-bs-theme; these overrides
+   re-map the custom design-system variables and the few hardcoded colors.
+   -------------------------------------------------------------------------- */
+[data-bs-theme="dark"] {
+    --bg-primary: #12151a;
+    --bg-secondary: #1c2027;
+    --text-primary: #e9ecef;
+    --text-secondary: #a5adb5;
+    --text-muted: #7a828a;
+    --card-border: #343a42;
+    --card-shadow: rgba(0, 0, 0, 0.45);
+    --link-color: #8fb3ee;
+    --link-hover: #b3ccf5;
+}
+
+/* Navy text reads as near-black on dark backgrounds — lift it to a legible blue */
+[data-bs-theme="dark"] .text-mlb-navy,
+[data-bs-theme="dark"] .player-card .stat-highlight,
+[data-bs-theme="dark"] .team-card .stat-highlight,
+[data-bs-theme="dark"] .table-baseball .rank-cell,
+[data-bs-theme="dark"] .alphabet-nav .letter-link {
+    color: #8fb3ee;
+}
+
+[data-bs-theme="dark"] .alphabet-nav .letter-link:hover,
+[data-bs-theme="dark"] .alphabet-nav .letter-link.active {
+    color: var(--mlb-white);
+}
+
+[data-bs-theme="dark"] .alphabet-nav .letter-link.disabled {
+    color: var(--text-muted);
+}
+
+/* Bootstrap's .text-black utility (leaderboard sort links) is !important */
+[data-bs-theme="dark"] .text-black {
+    color: var(--text-primary) !important;
+}
+
+[data-bs-theme="dark"] .table-baseball tbody tr:hover {
+    background-color: rgba(143, 179, 238, 0.08);
+}
+
+[data-bs-theme="dark"] .search-result-item:hover {
+    background-color: rgba(143, 179, 238, 0.08);
+}
+
+[data-bs-theme="dark"] .loading-overlay {
+    background: rgba(18, 21, 26, 0.85);
+}
+
+[data-bs-theme="dark"] .skeleton {
+    background: linear-gradient(90deg, #232830 25%, #2c323c 50%, #232830 75%);
+    background-size: 200% 100%;
+}
+
+[data-bs-theme="dark"] .btn:focus,
+[data-bs-theme="dark"] .btn:active:focus,
+[data-bs-theme="dark"] .btn-link.nav-link:focus,
+[data-bs-theme="dark"] .form-control:focus,
+[data-bs-theme="dark"] .form-check-input:focus {
+    box-shadow: 0 0 0 0.1rem var(--bg-primary), 0 0 0 0.25rem #8fb3ee;
+}
+
+/* --------------------------------------------------------------------------
+   Theme Toggle
+   -------------------------------------------------------------------------- */
+.theme-toggle {
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 1.1rem;
+    line-height: 1;
+}
+
+.theme-toggle:hover {
+    color: var(--mlb-white);
+}
+
+/* Show the icon for the theme you would switch TO */
+.theme-icon-dark,
+[data-bs-theme="dark"] .theme-icon-light {
+    display: none;
+}
+
+[data-bs-theme="dark"] .theme-icon-dark {
+    display: inline;
+}
+
+/* --------------------------------------------------------------------------
+   Modal Loading Overlay (issue #46)
+   Shown while any modal fragment is fetched via htmx.
+   -------------------------------------------------------------------------- */
+.modal-loading-overlay {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.35);
+    z-index: 1900;
+}
+
+.modal-loading-overlay.show {
+    display: flex;
+}
+
+.modal-loading-overlay .loading-baseball {
+    background: var(--bg-secondary);
+    border-radius: 0.5rem;
+    padding: 1.5rem 2.5rem;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}


### PR DESCRIPTION
Closes #44, closes #45, closes #46.

## Branded 404 + friendly error page (#44)
- `UseStatusCodePagesWithReExecute("/NotFound")` gives unmatched browser routes a baseball-themed 404 — "Swing and a Miss!" — with quick links to Home/Players/Teams/Leaders/HOF, while preserving the original URL and status code.
- Scoped via `UseWhen` to exclude `/api`, so REST clients keep getting bodyless 404s.
- `Error.cshtml` drops the ASP.NET boilerplate (including the "Development Mode" instructions shown to end users) for a friendly "Rain Delay" page that still surfaces the request ID.

## Dark mode (#45)
- Built on Bootstrap 5.3's native `data-bs-theme`; Bootstrap components restyle themselves.
- An inline script at the top of `<head>` applies the saved theme (or the OS `prefers-color-scheme`) **before first paint** — no flash of the wrong theme.
- Sun/moon toggle in the navbar, persisted to `localStorage`, wired with a delegated listener so it survives hx-boost swaps.
- `site.css` gains a dark block: the design-system variables remap, and targeted overrides fix the hardcoded colors (navy accent text lifts to a legible blue, leaderboard `.text-black` sort links, table hover, loading overlay, skeleton shimmer, focus rings). Team-color and navy gradient headers stay as-is — they're already dark-on-color.

## Loading feedback (#46)
- **Modal fetches**: a global overlay (spinning baseball on a dimmed backdrop) shows whenever htmx fetches into `#modal-container` — covering every player/team card and modal link app-wide without touching individual links. Wired off `htmx:beforeRequest`/`afterRequest`/error events.
- **Players & Teams browsers**: the same `hx-indicator` + `.loading-overlay` pattern the stats pages use, set on the content wrapper so filters, alphabet nav, league buttons, and pagination inherit it.

## Verification
- 10 new integration tests (`ErrorPagesAndPolishTests`): branded 404 for unknown routes and unknown players, bodyless API 404, dev-text-free error page, pre-paint theme script, navbar toggle, dark CSS rules served, and loading wiring on Players/Teams/layout.
- Two stale Error-page assertions updated.
- Full suite: **438/438 passing**. Live curl checks confirm the 404/500 pages, theme script ordering (before stylesheets), and indicator markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)