### PR TITLE
Fix pitching BB sort and truncated year dropdowns on leaders pages

### DIFF
--- a/baseball-history-tests/Pages/PitchingLeaderboardTests.cs
+++ b/baseball-history-tests/Pages/PitchingLeaderboardTests.cs
@@ -178,6 +178,31 @@ public class PitchingLeaderboardTests(WebApplicationFactory<Program> factory) : 
     }
 
     [Fact]
+    public async Task StatsPitching_SortByWalks_PutsCareerWalksLeaderFirst()
+    {
+        var html = await GetHtmxStringAsync("/Stats/Pitching?stat=bb&singleSeason=false");
+
+        // Nolan Ryan is the all-time walks leader (2,795); before the fix,
+        // stat=bb fell through to the default and sorted by wins (Cy Young first)
+        var firstRow = html.IndexOf("<tbody>", StringComparison.Ordinal);
+        var rowRegion = html.Substring(firstRow, 1500);
+        Assert.Contains("Nolan Ryan", rowRegion);
+        Assert.Contains("2,795", rowRegion);
+    }
+
+    [Theory]
+    [InlineData("/Stats/Pitching?stat=w")]
+    [InlineData("/Stats/Batting?stat=hr")]
+    public async Task StatsPages_YearDropdowns_SpanTheFullDataset(string url)
+    {
+        var html = await GetStringAsync(url);
+
+        // Lahman data starts in 1871; the dropdowns used to truncate at 1976
+        Assert.Contains("value=\"1871\"", html);
+        Assert.Contains("value=\"1950\"", html);
+    }
+
+    [Fact]
     public async Task StatsPitching_HOFBadge_AppearsForInductees()
     {
         var html = await GetHtmxStringAsync("/Stats/Pitching?stat=w&singleSeason=false");

--- a/baseball-history-web/Pages/Stats/Batting.cshtml
+++ b/baseball-history-web/Pages/Stats/Batting.cshtml
@@ -37,7 +37,7 @@
                                 hx-indicator="#loading-indicator"
                                 hx-push-url="true">
                             <option value="">All Time</option>
-                            @foreach (var year in Model.ViewModel.AvailableYears.Take(50))
+                            @foreach (var year in Model.ViewModel.AvailableYears)
                             {
                                 <option value="@year" selected="@(year == Model.ViewModel.FromYear)">@year</option>
                             }
@@ -52,7 +52,7 @@
                                 hx-indicator="#loading-indicator"
                                 hx-push-url="true">
                             <option value="">Present</option>
-                            @foreach (var year in Model.ViewModel.AvailableYears.Take(50))
+                            @foreach (var year in Model.ViewModel.AvailableYears)
                             {
                                 <option value="@year" selected="@(year == Model.ViewModel.ToYear)">@year</option>
                             }

--- a/baseball-history-web/Pages/Stats/Pitching.cshtml
+++ b/baseball-history-web/Pages/Stats/Pitching.cshtml
@@ -37,7 +37,7 @@
                                 hx-indicator="#loading-indicator"
                                 hx-push-url="true">
                             <option value="">All Time</option>
-                            @foreach (var year in Model.ViewModel.AvailableYears.Take(50))
+                            @foreach (var year in Model.ViewModel.AvailableYears)
                             {
                                 <option value="@year" selected="@(year == Model.ViewModel.FromYear)">@year</option>
                             }
@@ -52,7 +52,7 @@
                                 hx-indicator="#loading-indicator"
                                 hx-push-url="true">
                             <option value="">Present</option>
-                            @foreach (var year in Model.ViewModel.AvailableYears.Take(50))
+                            @foreach (var year in Model.ViewModel.AvailableYears)
                             {
                                 <option value="@year" selected="@(year == Model.ViewModel.ToYear)">@year</option>
                             }

--- a/baseball-history-web/Pages/Stats/Pitching.cshtml.cs
+++ b/baseball-history-web/Pages/Stats/Pitching.cshtml.cs
@@ -252,6 +252,7 @@ public class PitchingModel(BaseballDbContext context, IMemoryCache cache) : Page
             (IQueryable<T> q, "g" or "games") => q.OrderByDescending(DynExpr<T>("G")),
             (IQueryable<T> q, "gs" or "gamesstarted") => q.OrderByDescending(DynExpr<T>("GS")),
             (IQueryable<T> q, "hr") => q.OrderByDescending(DynExpr<T>("HR")),
+            (IQueryable<T> q, "bb" or "walks") => q.OrderByDescending(DynExpr<T>("BB")),
             (IQueryable<T> q, "k9" or "strikeoutsper9") => q.OrderByDescending(DynK9Expr<T>()),
             (IQueryable<T> q, "bb9" or "walksper9") => q.OrderBy(DynBb9Expr<T>()),
             (IQueryable<T> q, "wpct" or "winningpercentage") => q.OrderByDescending(DynWpctExpr<T>()),


### PR DESCRIPTION
Fixes two bugs on the leaderboard pages:

## BB column doesn't sort on Pitching Leaders
`ApplyPitchingOrder` had switch cases for `bb9`/`walksper9` but none for `bb` — so clicking the BB column header (or picking Walks) fell through to the default case and silently sorted by **wins**. Added the missing `"bb" or "walks"` case, ordering by BB descending. Batting Leaders already handled it correctly.

## From/To year dropdowns stop at 1976
Both leaders pages rendered the year selects with `AvailableYears.Take(50)`. The years list is ordered descending from 2025, and 2025 − 49 = **1976** — exactly where the dropdowns cut off. Removed the truncation in all four selects; they now span the full 1871–2025 dataset.

## Verification
- New regression tests: sorting pitching by BB puts Nolan Ryan (2,795 career walks) first — this failed before the fix, when Cy Young led via the wins fallback — and both stats pages must render `<option value="1871">`.
- Full suite: **441/441 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)