### PR TITLE
Finish rhx-badge migration for visual consistency

### DIFF
--- a/baseball-history-web/Pages/ApiDocs.cshtml
+++ b/baseball-history-web/Pages/ApiDocs.cshtml
@@ -53,7 +53,7 @@
                 <h2 class="border-bottom pb-2">Players</h2>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/players</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/players</code></h5>
                     <p>List players filtered by last name initial.</p>
                     <table class="table table-sm">
                         <thead><tr><th>Parameter</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
@@ -68,39 +68,39 @@
                 </div>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/players/{playerId}</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/players/{playerId}</code></h5>
                     <p>Full player detail including career batting/pitching stats, teams played for, and Hall of Fame status.</p>
                     <p><strong>Example:</strong></p>
                     <pre class="bg-dark text-light p-3 rounded"><code>curl "https://your-host/api/players/ruthba01"</code></pre>
                 </div>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/players/{playerId}/batting</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/players/{playerId}/batting</code></h5>
                     <p>Season-by-season batting statistics with team names and computed batting average.</p>
                 </div>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/players/{playerId}/pitching</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/players/{playerId}/pitching</code></h5>
                     <p>Season-by-season pitching statistics with ERA.</p>
                 </div>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/players/{playerId}/fielding</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/players/{playerId}/fielding</code></h5>
                     <p>Season-by-season fielding stats by position (putouts, assists, errors, double plays).</p>
                 </div>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/players/{playerId}/awards</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/players/{playerId}/awards</code></h5>
                     <p>All awards won (MVP, Cy Young, Gold Glove, etc.).</p>
                 </div>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/players/{playerId}/postseason/batting</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/players/{playerId}/postseason/batting</code></h5>
                     <p>Postseason batting stats by year and round (ALCS, NLCS, WS, etc.).</p>
                 </div>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/players/{playerId}/postseason/pitching</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/players/{playerId}/postseason/pitching</code></h5>
                     <p>Postseason pitching stats by year and round.</p>
                 </div>
             </section>
@@ -110,7 +110,7 @@
                 <h2 class="border-bottom pb-2">Teams</h2>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/teams/franchises</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/teams/franchises</code></h5>
                     <p>List all franchises with all-time records, championships, and pennants.</p>
                     <table class="table table-sm">
                         <thead><tr><th>Parameter</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
@@ -124,14 +124,14 @@
                 </div>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/teams/franchises/{franchiseId}</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/teams/franchises/{franchiseId}</code></h5>
                     <p>Franchise detail with every season's record, division/pennant/World Series wins.</p>
                     <p><strong>Example:</strong></p>
                     <pre class="bg-dark text-light p-3 rounded"><code>curl "https://your-host/api/teams/franchises/NYY"</code></pre>
                 </div>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/teams/seasons/{teamId}/{lgId}/{year}</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/teams/seasons/{teamId}/{lgId}/{year}</code></h5>
                     <p>
                         Complete team season: record, batting/pitching aggregates, full roster
                         (batters and pitchers), and managers. Includes Hall of Fame flags.
@@ -146,7 +146,7 @@
                 <h2 class="border-bottom pb-2">Leaders</h2>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/leaders/batting</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/leaders/batting</code></h5>
                     <p>Batting leaderboard ranked by any stat. Supports career and single-season modes.</p>
                     <table class="table table-sm">
                         <thead><tr><th>Parameter</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
@@ -166,7 +166,7 @@
                 </div>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/leaders/pitching</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/leaders/pitching</code></h5>
                     <p>Pitching leaderboard. ERA and WHIP sort ascending (lower is better); all others descending.</p>
                     <table class="table table-sm">
                         <thead><tr><th>Parameter</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
@@ -191,7 +191,7 @@
                 <h2 class="border-bottom pb-2">Hall of Fame</h2>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/hall-of-fame</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/hall-of-fame</code></h5>
                     <p>List Hall of Fame inductees with vote percentages.</p>
                     <table class="table table-sm">
                         <thead><tr><th>Parameter</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
@@ -205,7 +205,7 @@
                 </div>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/hall-of-fame/{playerId}/voting</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/hall-of-fame/{playerId}/voting</code></h5>
                     <p>Complete voting history for a player across all ballot years.</p>
                     <p><strong>Example:</strong></p>
                     <pre class="bg-dark text-light p-3 rounded"><code>curl "https://your-host/api/hall-of-fame/jeterda01/voting"</code></pre>
@@ -217,7 +217,7 @@
                 <h2 class="border-bottom pb-2">Search</h2>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/search</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/search</code></h5>
                     <p>Search across players and franchises by name. Returns both result types with total counts.</p>
                     <table class="table table-sm">
                         <thead><tr><th>Parameter</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
@@ -236,21 +236,21 @@
                 <h2 class="border-bottom pb-2">Salaries</h2>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/salaries/players/{playerId}</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/salaries/players/{playerId}</code></h5>
                     <p>Player salary history with career total. Data available from 1985 onward.</p>
                     <p><strong>Example:</strong></p>
                     <pre class="bg-dark text-light p-3 rounded"><code>curl "https://your-host/api/salaries/players/troutmi01"</code></pre>
                 </div>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/salaries/teams/{teamId}/{year}</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/salaries/teams/{teamId}/{year}</code></h5>
                     <p>Team payroll breakdown for a given season.</p>
                     <p><strong>Example:</strong></p>
                     <pre class="bg-dark text-light p-3 rounded"><code>curl "https://your-host/api/salaries/teams/NYA/2014"</code></pre>
                 </div>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/salaries/leaders</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/salaries/leaders</code></h5>
                     <p>Highest-paid players. Paginated.</p>
                     <table class="table table-sm">
                         <thead><tr><th>Parameter</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
@@ -268,7 +268,7 @@
                 <h2 class="border-bottom pb-2">Ballparks</h2>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/parks</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/parks</code></h5>
                     <p>List all ballparks. Paginated.</p>
                     <table class="table table-sm">
                         <thead><tr><th>Parameter</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
@@ -281,7 +281,7 @@
                 </div>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/parks/{parkKey}</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/parks/{parkKey}</code></h5>
                     <p>Park detail with season-by-season attendance and game counts.</p>
                 </div>
             </section>
@@ -291,7 +291,7 @@
                 <h2 class="border-bottom pb-2">Postseason</h2>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/postseason/series</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/postseason/series</code></h5>
                     <p>Postseason series results (World Series, LCS, Division Series, Wild Card). Paginated.</p>
                     <table class="table table-sm">
                         <thead><tr><th>Parameter</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
@@ -307,7 +307,7 @@
                 </div>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/postseason/series/{year}</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/postseason/series/{year}</code></h5>
                     <p>All postseason series for a given year.</p>
                     <p><strong>Example:</strong></p>
                     <pre class="bg-dark text-light p-3 rounded"><code>curl "https://your-host/api/postseason/series/2024"</code></pre>
@@ -319,7 +319,7 @@
                 <h2 class="border-bottom pb-2">Awards</h2>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/awards/winners</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/awards/winners</code></h5>
                     <p>Award winners with optional filters. Paginated.</p>
                     <table class="table table-sm">
                         <thead><tr><th>Parameter</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
@@ -336,7 +336,7 @@
                 </div>
 
                 <div class="api-endpoint mb-4">
-                    <h5><span class="badge bg-success me-2">GET</span><code>/api/awards/voting/{awardId}/{year}/{lgId}</code></h5>
+                    <h5><rhx-badge rhx-variant="success" class="me-2">GET</rhx-badge><code>/api/awards/voting/{awardId}/{year}/{lgId}</code></h5>
                     <p>
                         Full voting breakdown for an award race. Shows every candidate with points won,
                         max possible, first-place votes, and vote share percentage.

--- a/baseball-history-web/Pages/Awards/_AwardsList.cshtml
+++ b/baseball-history-web/Pages/Awards/_AwardsList.cshtml
@@ -37,7 +37,7 @@
                             </a>
                             @if (vote.IsWinner)
                             {
-                                <span class="badge bg-success ms-1">Winner</span>
+                                <rhx-badge rhx-variant="success" class="ms-1">Winner</rhx-badge>
                             }
                             @if (vote.IsInHallOfFame)
                             {
@@ -82,7 +82,7 @@ else
     <div class="card mt-3">
         <div class="card-header card-header-mlb d-flex justify-content-between align-items-center">
             <strong>Award Winners</strong>
-            <span class="badge bg-light text-dark">@Model.TotalEntries.ToString("N0") awards</span>
+            <rhx-badge rhx-variant="neutral">@Model.TotalEntries.ToString("N0") awards</rhx-badge>
         </div>
         <div class="table-responsive">
             <table class="table table-baseball table-hover mb-0">
@@ -114,7 +114,7 @@ else
                             }
                         </td>
                         <td>
-                            <span class="badge bg-primary">@winner.AwardId</span>
+                            <rhx-badge rhx-variant="brand">@winner.AwardId</rhx-badge>
                         </td>
                         <td class="text-center fw-bold text-mlb-navy">@winner.Year</td>
                         <td class="text-center">@winner.LgId</td>

--- a/baseball-history-web/Pages/Compare/_CompareSearchResults.cshtml
+++ b/baseball-history-web/Pages/Compare/_CompareSearchResults.cshtml
@@ -33,7 +33,7 @@
                         <span class="text-muted small ms-2">@player.DebutYear - @(player.FinalYear ?? "Present")</span>
                     }
                 </div>
-                <span class="badge bg-primary">Select</span>
+                <rhx-badge rhx-variant="brand">Select</rhx-badge>
             </a>
         }
     </div>

--- a/baseball-history-web/Pages/HallOfFame/_InducteeList.cshtml
+++ b/baseball-history-web/Pages/HallOfFame/_InducteeList.cshtml
@@ -15,7 +15,7 @@ else
     <div class="card">
         <div class="card-header card-header-mlb d-flex justify-content-between align-items-center">
             <strong>Hall of Fame Inductees</strong>
-            <span class="badge bg-light text-dark">@Model.TotalInductees.ToString("N0") inductees</span>
+            <rhx-badge rhx-variant="neutral">@Model.TotalInductees.ToString("N0") inductees</rhx-badge>
         </div>
         <div class="table-responsive">
             <table class="table table-baseball table-hover mb-0">
@@ -50,19 +50,19 @@ else
                             @switch (inductee.Category)
                             {
                                 case "Player":
-                                    <span class="badge bg-primary">Player</span>
+                                    <rhx-badge rhx-variant="brand">Player</rhx-badge>
                                     break;
                                 case "Manager":
-                                    <span class="badge bg-success">Manager</span>
+                                    <rhx-badge rhx-variant="success">Manager</rhx-badge>
                                     break;
                                 case "Pioneer/Executive":
-                                    <span class="badge bg-secondary">Pioneer</span>
+                                    <rhx-badge rhx-variant="neutral">Pioneer</rhx-badge>
                                     break;
                                 case "Umpire":
-                                    <span class="badge bg-info">Umpire</span>
+                                    <rhx-badge rhx-variant="warning">Umpire</rhx-badge>
                                     break;
                                 default:
-                                    <span class="badge bg-light text-dark">@inductee.Category</span>
+                                    <rhx-badge rhx-variant="neutral">@inductee.Category</rhx-badge>
                                     break;
                             }
                         </td>

--- a/baseball-history-web/Pages/McpDocs.cshtml
+++ b/baseball-history-web/Pages/McpDocs.cshtml
@@ -99,21 +99,21 @@
 
             <h5 class="mt-3">Players</h5>
             <ul class="list-unstyled">
-                <li class="mb-2"><span class="badge bg-secondary me-2">search_players</span> Search players by free-text query or last-name prefix with paging.</li>
-                <li class="mb-2"><span class="badge bg-secondary me-2">get_player</span> Get read-only detail for one player, including career batting, career pitching, and team tenures.</li>
+                <li class="mb-2"><rhx-badge rhx-variant="neutral" class="me-2">search_players</rhx-badge> Search players by free-text query or last-name prefix with paging.</li>
+                <li class="mb-2"><rhx-badge rhx-variant="neutral" class="me-2">get_player</rhx-badge> Get read-only detail for one player, including career batting, career pitching, and team tenures.</li>
             </ul>
 
             <h5 class="mt-3">Franchises &amp; Teams</h5>
             <ul class="list-unstyled">
-                <li class="mb-2"><span class="badge bg-secondary me-2">list_franchises</span> List franchise summaries with optional filters and bounded paging.</li>
-                <li class="mb-2"><span class="badge bg-secondary me-2">get_franchise</span> Get one franchise with season-by-season history.</li>
-                <li class="mb-2"><span class="badge bg-secondary me-2">get_team_season</span> Get one exact team-season by team id, league, and year so franchise-era lookups stay deterministic.</li>
+                <li class="mb-2"><rhx-badge rhx-variant="neutral" class="me-2">list_franchises</rhx-badge> List franchise summaries with optional filters and bounded paging.</li>
+                <li class="mb-2"><rhx-badge rhx-variant="neutral" class="me-2">get_franchise</rhx-badge> Get one franchise with season-by-season history.</li>
+                <li class="mb-2"><rhx-badge rhx-variant="neutral" class="me-2">get_team_season</rhx-badge> Get one exact team-season by team id, league, and year so franchise-era lookups stay deterministic.</li>
             </ul>
 
             <h5 class="mt-3">Leaderboards</h5>
 
             <div class="mb-4">
-                <h6><span class="badge bg-secondary me-2">get_batting_leaders</span></h6>
+                <h6><rhx-badge rhx-variant="neutral" class="me-2">get_batting_leaders</rhx-badge></h6>
                 <p>Read batting leaderboards in career or single-season form.</p>
                 <table class="table table-sm">
                     <thead><tr><th>Parameter</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
@@ -131,7 +131,7 @@
             </div>
 
             <div class="mb-4">
-                <h6><span class="badge bg-secondary me-2">get_pitching_leaders</span></h6>
+                <h6><rhx-badge rhx-variant="neutral" class="me-2">get_pitching_leaders</rhx-badge></h6>
                 <p>Read pitching leaderboards in career or single-season form. ERA, WHIP, and BB9 sort ascending (lower is better); all others descending.</p>
                 <table class="table table-sm">
                     <thead><tr><th>Parameter</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
@@ -150,19 +150,19 @@
 
             <h5 class="mt-3">Hall of Fame</h5>
             <ul class="list-unstyled">
-                <li class="mb-2"><span class="badge bg-secondary me-2">list_hall_of_fame_inductees</span> List inducted Hall of Fame rows with optional year/category filters and bounded paging.</li>
-                <li class="mb-2"><span class="badge bg-secondary me-2">get_hall_of_fame_voting_history</span> Get bounded Hall of Fame voting history for one player. Rows are Lahman HallOfFame ballot rows, not a prose biography.</li>
+                <li class="mb-2"><rhx-badge rhx-variant="neutral" class="me-2">list_hall_of_fame_inductees</rhx-badge> List inducted Hall of Fame rows with optional year/category filters and bounded paging.</li>
+                <li class="mb-2"><rhx-badge rhx-variant="neutral" class="me-2">get_hall_of_fame_voting_history</rhx-badge> Get bounded Hall of Fame voting history for one player. Rows are Lahman HallOfFame ballot rows, not a prose biography.</li>
             </ul>
 
             <h5 class="mt-3">Salaries</h5>
             <ul class="list-unstyled">
-                <li class="mb-2"><span class="badge bg-secondary me-2">get_player_salary_history</span> Get bounded salary history for one player, ordered most recent to oldest.</li>
-                <li class="mb-2"><span class="badge bg-secondary me-2">get_salary_leaders</span> List highest salary rows with optional year filter and bounded paging.</li>
+                <li class="mb-2"><rhx-badge rhx-variant="neutral" class="me-2">get_player_salary_history</rhx-badge> Get bounded salary history for one player, ordered most recent to oldest.</li>
+                <li class="mb-2"><rhx-badge rhx-variant="neutral" class="me-2">get_salary_leaders</rhx-badge> List highest salary rows with optional year filter and bounded paging.</li>
             </ul>
 
             <h5 class="mt-3">Diagnostics</h5>
             <ul class="list-unstyled">
-                <li class="mb-2"><span class="badge bg-secondary me-2">get_server_diagnostics</span> Inspect safe runtime posture, configured limits, and connectivity without exposing secrets.</li>
+                <li class="mb-2"><rhx-badge rhx-variant="neutral" class="me-2">get_server_diagnostics</rhx-badge> Inspect safe runtime posture, configured limits, and connectivity without exposing secrets.</li>
             </ul>
         </section>
 

--- a/baseball-history-web/Pages/Postseason/_PostseasonList.cshtml
+++ b/baseball-history-web/Pages/Postseason/_PostseasonList.cshtml
@@ -15,7 +15,7 @@ else
     <div class="card mt-3">
         <div class="card-header card-header-mlb d-flex justify-content-between align-items-center">
             <strong>Postseason Series</strong>
-            <span class="badge bg-light text-dark">@Model.TotalSeries.ToString("N0") series</span>
+            <rhx-badge rhx-variant="neutral">@Model.TotalSeries.ToString("N0") series</rhx-badge>
         </div>
         <div class="table-responsive">
             <table class="table table-baseball table-hover mb-0">
@@ -45,7 +45,7 @@ else
                         <td>
                             @if (isWorldSeries)
                             {
-                                <span class="badge bg-warning text-dark">@series.RoundName</span>
+                                <rhx-badge rhx-variant="warning">@series.RoundName</rhx-badge>
                             }
                             else
                             {

--- a/baseball-history-web/Pages/Salaries/_SalaryList.cshtml
+++ b/baseball-history-web/Pages/Salaries/_SalaryList.cshtml
@@ -25,7 +25,7 @@ else
     <div class="card mt-3">
         <div class="card-header card-header-mlb d-flex justify-content-between align-items-center">
             <strong>Player Salaries</strong>
-            <span class="badge bg-light text-dark">@Model.TotalEntries.ToString("N0") records</span>
+            <rhx-badge rhx-variant="neutral">@Model.TotalEntries.ToString("N0") records</rhx-badge>
         </div>
         <div class="table-responsive">
             <table class="table table-baseball table-hover mb-0">

--- a/baseball-history-web/Pages/_HomeLeaderboards.cshtml
+++ b/baseball-history-web/Pages/_HomeLeaderboards.cshtml
@@ -11,7 +11,7 @@
                 {
                     <li class="list-group-item d-flex justify-content-between align-items-center">
                         <span>
-                            <span class="badge bg-secondary me-2">@leader.Rank</span>
+                            <rhx-badge rhx-variant="neutral" class="me-2">@leader.Rank</rhx-badge>
                             <a href="/Players/@leader.PlayerId" class="text-decoration-none"
                                hx-get="/Players/Modal/@leader.PlayerId"
                                hx-target="#modal-container"
@@ -44,7 +44,7 @@
                 {
                     <li class="list-group-item d-flex justify-content-between align-items-center">
                         <span>
-                            <span class="badge bg-secondary me-2">@leader.Rank</span>
+                            <rhx-badge rhx-variant="neutral" class="me-2">@leader.Rank</rhx-badge>
                             <a href="/Players/@leader.PlayerId" class="text-decoration-none"
                                hx-get="/Players/Modal/@leader.PlayerId"
                                hx-target="#modal-container"


### PR DESCRIPTION
Migrates the remaining Bootstrap `.badge` spans to `rhx-badge` components so badges render consistently everywhere:

- **Hall of Fame inductee list** — inductee count and category badges (Player → brand, Manager → success, Pioneer → neutral, Umpire → warning, fallback → neutral)
- **Home leaderboards** — rank badges → neutral
- **Awards list** — award count, "Winner" badge (success), award id chip (brand)
- **Postseason list** — series count, World Series round badge (warning)
- **Salary list** — record count badge
- **Compare search results** — "Select" chip (brand)
- **ApiDocs / McpDocs** — GET method chips (success) and MCP tool-name chips (neutral)

The custom gold `.hof-badge` and `.stat-badge` components are intentional designs and were left untouched.

Fixes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)