### PR TITLE
Leaderboard sort direction indicators and aria-sort

### DIFF
--- a/baseball-history-web/Pages/Stats/_BattingLeaders.cshtml
+++ b/baseball-history-web/Pages/Stats/_BattingLeaders.cshtml
@@ -29,7 +29,7 @@ else
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            G @(Model.StatColumn == "g" ? "↓" : "")
+                            G @if (Model.StatColumn == "g") {<span aria-hidden="true">▼</span>}
                         </a>
                     </th>
                     <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "ab" ? "descending" : null)">
@@ -38,7 +38,7 @@ else
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            AB @(Model.StatColumn == "ab" ? "↓" : "")
+                            AB @if (Model.StatColumn == "ab") {<span aria-hidden="true">▼</span>}
                         </a>
                     </th>
                     <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "h" ? "descending" : null)">
@@ -47,7 +47,7 @@ else
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            H @(Model.StatColumn == "h" ? "↓" : "")
+                            H @if (Model.StatColumn == "h") {<span aria-hidden="true">▼</span>}
                         </a>
                     </th>
                     <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "2b" ? "descending" : null)">
@@ -56,7 +56,7 @@ else
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            2B @(Model.StatColumn == "2b" ? "↓" : "")
+                            2B @if (Model.StatColumn == "2b") {<span aria-hidden="true">▼</span>}
                         </a>
                     </th>
                     <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "3b" ? "descending" : null)">
@@ -65,7 +65,7 @@ else
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            3B @(Model.StatColumn == "3b" ? "↓" : "")
+                            3B @if (Model.StatColumn == "3b") {<span aria-hidden="true">▼</span>}
                         </a>
                     </th>
                     <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "hr" ? "descending" : null)">
@@ -74,7 +74,7 @@ else
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            HR @(Model.StatColumn == "hr" ? "↓" : "")
+                            HR @if (Model.StatColumn == "hr") {<span aria-hidden="true">▼</span>}
                         </a>
                     </th>
                     <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "rbi" ? "descending" : null)">
@@ -83,7 +83,7 @@ else
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            RBI @(Model.StatColumn == "rbi" ? "↓" : "")
+                            RBI @if (Model.StatColumn == "rbi") {<span aria-hidden="true">▼</span>}
                         </a>
                     </th>
                     <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "r" ? "descending" : null)">
@@ -92,7 +92,7 @@ else
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            R @(Model.StatColumn == "r" ? "↓" : "")
+                            R @if (Model.StatColumn == "r") {<span aria-hidden="true">▼</span>}
                         </a>
                     </th>
                     <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "sb" ? "descending" : null)">
@@ -101,7 +101,7 @@ else
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            SB @(Model.StatColumn == "sb" ? "↓" : "")
+                            SB @if (Model.StatColumn == "sb") {<span aria-hidden="true">▼</span>}
                         </a>
                     </th>
                     <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "bb" ? "descending" : null)">
@@ -110,7 +110,7 @@ else
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            BB @(Model.StatColumn == "bb" ? "↓" : "")
+                            BB @if (Model.StatColumn == "bb") {<span aria-hidden="true">▼</span>}
                         </a>
                     </th>
                     <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "avg" ? "descending" : null)">
@@ -119,7 +119,7 @@ else
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            AVG @(Model.StatColumn == "avg" ? "↓" : "")
+                            AVG @if (Model.StatColumn == "avg") {<span aria-hidden="true">▼</span>}
                         </a>
                     </th>
                     <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "ops" ? "descending" : null)">
@@ -128,7 +128,7 @@ else
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            OPS @(Model.StatColumn == "ops" ? "↓" : "")
+                            OPS @if (Model.StatColumn == "ops") {<span aria-hidden="true">▼</span>}
                         </a>
                     </th>
                 </tr>

--- a/baseball-history-web/Pages/Stats/_PitchingLeaders.cshtml
+++ b/baseball-history-web/Pages/Stats/_PitchingLeaders.cshtml
@@ -29,7 +29,7 @@ else
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            G @Html.Raw(Model.StatColumn == "g" ? "↓" : "")
+                            G @if (Model.StatColumn == "g") {<span aria-hidden="true">▼</span>}
                         </a>
                     </th>
                     <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "gs" ? "descending" : null)">
@@ -38,7 +38,7 @@ else
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            GS @Html.Raw(Model.StatColumn == "gs" ? "↓" : "")
+                            GS @if (Model.StatColumn == "gs") {<span aria-hidden="true">▼</span>}
                         </a>
                     </th>
                     <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "w" ? "descending" : null)">
@@ -47,7 +47,7 @@ else
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            W @Html.Raw(Model.StatColumn == "w" ? "↓" : "")
+                            W @if (Model.StatColumn == "w") {<span aria-hidden="true">▼</span>}
                         </a>
                     </th>
                     <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "l" ? "descending" : null)">
@@ -56,7 +56,7 @@ else
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            L @Html.Raw(Model.StatColumn == "l" ? "↑" : "")
+                            L @if (Model.StatColumn == "l") {<span aria-hidden="true">▼</span>}
                         </a>
                     </th>
                     <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "sv" ? "descending" : null)">
@@ -65,7 +65,7 @@ else
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            SV @Html.Raw(Model.StatColumn == "sv" ? "↓" : "")
+                            SV @if (Model.StatColumn == "sv") {<span aria-hidden="true">▼</span>}
                         </a>
                     </th>
                     <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "ip" ? "descending" : null)">
@@ -74,7 +74,7 @@ else
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            IP @Html.Raw(Model.StatColumn == "ip" ? "↓" : "")
+                            IP @if (Model.StatColumn == "ip") {<span aria-hidden="true">▼</span>}
                         </a>
                     </th>
                     <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "so" ? "descending" : null)">
@@ -83,7 +83,7 @@ else
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            SO @Html.Raw(Model.StatColumn == "so" ? "↓" : "")
+                            SO @if (Model.StatColumn == "so") {<span aria-hidden="true">▼</span>}
                         </a>
                     </th>
                     <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "bb" ? "descending" : null)">
@@ -92,25 +92,25 @@ else
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            BB @Html.Raw(Model.StatColumn == "bb" ? "↑" : "")
+                            BB @if (Model.StatColumn == "bb") {<span aria-hidden="true">▼</span>}
                         </a>
                     </th>
-                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "era" ? "descending" : null)">
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "era" ? "ascending" : null)">
                         <a href="/Stats/Pitching?stat=era" class="text-black text-decoration-none @(Model.StatColumn == "era" ? "fw-bold" : "")"
                            hx-get="/Stats/Pitching?stat=era"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            ERA @Html.Raw(Model.StatColumn == "era" ? "↑" : "")
+                            ERA @if (Model.StatColumn == "era") {<span aria-hidden="true">▲</span>}
                         </a>
                     </th>
-                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "whip" ? "descending" : null)">
+                    <th class="text-end" scope="col" aria-sort="@(Model.StatColumn == "whip" ? "ascending" : null)">
                         <a href="/Stats/Pitching?stat=whip" class="text-black text-decoration-none @(Model.StatColumn == "whip" ? "fw-bold" : "")"
                            hx-get="/Stats/Pitching?stat=whip"
                            hx-include="#filter-form"
                            hx-target="#leaderboard"
                            hx-push-url="true">
-                            WHIP @Html.Raw(Model.StatColumn == "whip" ? "↑" : "")
+                            WHIP @if (Model.StatColumn == "whip") {<span aria-hidden="true">▲</span>}
                         </a>
                     </th>
                 </tr>


### PR DESCRIPTION
Replaces the lone `↓` on active leaderboard columns with proper ▲/▼ indicators that reflect the actual sort direction, and makes `aria-sort` report the real direction.

- **Batting leaders**: all 12 sortable columns show ▼ when active (every batting stat sorts descending); `aria-sort="descending"` unchanged.
- **Pitching leaders**: ERA and WHIP sort ascending (lower is better) — they now show ▲ and report `aria-sort="ascending"` instead of incorrectly claiming descending. L and BB previously displayed a misleading `↑` even though they sort descending (most losses / most walks) — they now show ▼.
- Indicators are wrapped in `<span aria-hidden="true">` so screen readers get the direction from `aria-sort` rather than a glyph name.

Fixes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)