### PR TITLE
Small UX touches: back-to-top, roster counts, richer search empty state

### DIFF
--- a/baseball-history-web/Pages/Shared/_Layout.cshtml
+++ b/baseball-history-web/Pages/Shared/_Layout.cshtml
@@ -53,6 +53,10 @@
     @await Html.PartialAsync("Components/_LoadingSpinner", "Loading player...")
 </div>
 
+<button type="button" id="back-to-top" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <span aria-hidden="true">&uarr;</span>
+</button>
+
 @await Html.PartialAsync("_ShellFooter")
 
 <script>
@@ -181,6 +185,18 @@
                     setModalLoading(false);
                 }
             });
+        });
+
+        // Back-to-top button (delegated so it survives hx-boost swaps)
+        window.addEventListener('scroll', function () {
+            var backToTop = document.getElementById('back-to-top');
+            if (backToTop) backToTop.classList.toggle('show', window.scrollY > 600);
+        }, { passive: true });
+
+        document.addEventListener('click', function (e) {
+            if (e.target.closest('#back-to-top')) {
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+            }
         });
 
         // Theme toggle (button lives in the navbar, delegated so it survives hx-boost swaps)

--- a/baseball-history-web/Pages/Teams/_TeamSeason.cshtml
+++ b/baseball-history-web/Pages/Teams/_TeamSeason.cshtml
@@ -130,8 +130,9 @@
         {
             <div class="col-lg-6 mb-4">
                 <div class="card">
-                    <div class="card-header card-header-mlb">
+                    <div class="card-header card-header-mlb d-flex justify-content-between align-items-center">
                         <strong>Batting</strong>
+                        <rhx-badge rhx-variant="neutral">@(Model.Batters.Count > 25 ? $"top 25 of {Model.Batters.Count}" : Model.Batters.Count.ToString()) players</rhx-badge>
                     </div>
                     <div class="table-responsive" style="max-height: 500px;">
                         <table class="table table-sm table-baseball table-hover mb-0">
@@ -183,8 +184,9 @@
         {
             <div class="col-lg-6 mb-4">
                 <div class="card">
-                    <div class="card-header card-header-mlb">
+                    <div class="card-header card-header-mlb d-flex justify-content-between align-items-center">
                         <strong>Pitching</strong>
+                        <rhx-badge rhx-variant="neutral">@(Model.Pitchers.Count > 25 ? $"top 25 of {Model.Pitchers.Count}" : Model.Pitchers.Count.ToString()) players</rhx-badge>
                     </div>
                     <div class="table-responsive" style="max-height: 500px;">
                         <table class="table table-sm table-baseball table-hover mb-0">

--- a/baseball-history-web/Pages/_SearchAllResultsModal.cshtml
+++ b/baseball-history-web/Pages/_SearchAllResultsModal.cshtml
@@ -13,8 +13,19 @@
             <div class="modal-body">
                 @if (!Model.HasResults)
                 {
-                    <div class="text-center text-muted py-4">
-                        No results found for "@Model.Query"
+                    <div class="text-center py-4">
+                        <div class="text-muted">No results found for "@Model.Query"</div>
+                        <small class="text-muted d-block mb-3">Check the spelling or try just a last name.</small>
+                        <h6 class="text-muted fw-bold">POPULAR PLAYERS</h6>
+                        <div class="d-flex flex-wrap justify-content-center gap-2 mb-3">
+                            @foreach (var (id, name) in new[] { ("ruthba01", "Babe Ruth"), ("aaronha01", "Hank Aaron"), ("mayswi01", "Willie Mays"), ("jeterde01", "Derek Jeter"), ("ohtansh01", "Shohei Ohtani") })
+                            {
+                                <a href="/Players/@id" class="btn btn-sm btn-outline-primary rounded-pill" data-bs-dismiss="modal">
+                                    @name
+                                </a>
+                            }
+                        </div>
+                        <a href="/Players" class="small text-decoration-none" data-bs-dismiss="modal">Browse all players</a>
                     </div>
                 }
                 else

--- a/baseball-history-web/Pages/_SearchResults.cshtml
+++ b/baseball-history-web/Pages/_SearchResults.cshtml
@@ -4,8 +4,25 @@
 {
     @if (!string.IsNullOrEmpty(Model.Query))
     {
-        <div class="search-result-item text-center text-muted py-3">
-            No results found for "@Model.Query"
+        <div class="search-result-item text-center py-3">
+            <div class="text-muted">No results found for "@Model.Query"</div>
+            <small class="text-muted d-block mb-2">Check the spelling or try just a last name.</small>
+            <small class="text-muted fw-bold d-block mb-2">POPULAR PLAYERS</small>
+            <div class="d-flex flex-wrap justify-content-center gap-2 px-3">
+                @foreach (var (id, name) in new[] { ("ruthba01", "Babe Ruth"), ("aaronha01", "Hank Aaron"), ("mayswi01", "Willie Mays"), ("jeterde01", "Derek Jeter"), ("ohtansh01", "Shohei Ohtani") })
+                {
+                    <a href="/Players/@id" class="btn btn-sm btn-outline-primary rounded-pill"
+                       onclick="document.getElementById('search-results').innerHTML = '';">
+                        @name
+                    </a>
+                }
+            </div>
+            <div class="pt-2">
+                <a href="/Players" class="small text-decoration-none"
+                   onclick="document.getElementById('search-results').innerHTML = '';">
+                    Browse all players
+                </a>
+            </div>
         </div>
     }
 }

--- a/baseball-history-web/wwwroot/css/site.css
+++ b/baseball-history-web/wwwroot/css/site.css
@@ -811,3 +811,44 @@ a:hover {
     color: #fff;
     text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
 }
+
+/* --------------------------------------------------------------------------
+   Back to Top
+   -------------------------------------------------------------------------- */
+.back-to-top {
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    width: 2.75rem;
+    height: 2.75rem;
+    border: none;
+    border-radius: 50%;
+    background: var(--mlb-navy);
+    color: var(--mlb-white);
+    font-size: 1.25rem;
+    line-height: 1;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(0.5rem);
+    transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s;
+    z-index: 1030;
+}
+
+.back-to-top.show {
+    opacity: 1;
+    visibility: visible;
+    transform: none;
+}
+
+.back-to-top:hover {
+    background: var(--mlb-navy-light);
+}
+
+[data-bs-theme="dark"] .back-to-top {
+    background: var(--mlb-navy-light);
+}
+
+[data-bs-theme="dark"] .back-to-top:hover {
+    background: var(--mlb-navy);
+}


### PR DESCRIPTION
Three polish items from #50:

- **Back-to-top button** — a floating button in the layout fades in after scrolling past 600px and smooth-scrolls to the top. Click/scroll handlers are delegated at the document/window level so the button keeps working across `hx-boost` body swaps, matching the existing init pattern. Styled for both light and dark themes.
- **Result-count context** — the team season Batting/Pitching roster cards were the remaining tables without counts; they now show a neutral `rhx-badge` with the roster size, rendered as "top 25 of N players" when the table truncates at 25 rows.
- **Richer search empty state** — both the navbar dropdown and the all-results modal now suggest checking spelling / trying a last name, offer popular-player quick links (Ruth, Aaron, Mays, Jeter, Ohtani — IDs verified against the Lahman People table), and link to browsing all players.

Verified: `dotnet build` clean and the 69 navigation/accessibility/routing/polish integration tests pass.

Fixes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)